### PR TITLE
chore(auth): split embedded outpost binding into dedicated blueprint

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -46,6 +46,7 @@ spec:
       configMaps:
         - grafana-blueprint
         - ops-blueprint
+        - embedded-outpost-blueprint
     server:
       ingress:
         hosts:

--- a/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
@@ -1,0 +1,28 @@
+# Single binder for the Authentik embedded outpost's `providers` list.
+#
+# The embedded outpost has one M2M `providers` field. DRF replaces (does not
+# merge) that list on each blueprint apply, so only ONE blueprint can bind the
+# outpost without flapping. Per-app forward-auth blueprints define their
+# ProxyProvider and Application; this blueprint is the only place that binds
+# providers to the embedded outpost, referencing each by name via !Find.
+#
+# To add a new forward-auth host: create the per-app blueprint, then add a
+# !Find entry for its provider name to the providers list below.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embedded-outpost-blueprint
+  namespace: default
+data:
+  embedded-outpost.yaml: |
+    version: 1
+    metadata:
+      name: embedded-outpost-bindings
+    entries:
+      - model: authentik_outposts.outpost
+        id: embedded-outpost
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          providers:
+            - !Find [authentik_providers_proxy.proxyprovider, [name, ops-forward-auth]]

--- a/apps/prod/authentik/blueprints/embedded-outpost/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafana
-  - ops
-  - embedded-outpost
+  - embedded-outpost.blueprint.yaml

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -26,14 +26,10 @@ data:
           mode: forward_single
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-      # Bind provider to the embedded outpost
-      - model: authentik_outposts.outpost
-        id: embedded-outpost
-        identifiers:
-          name: authentik Embedded Outpost
-        attrs:
-          providers:
-            - !KeyOf ops-provider
+      # The embedded outpost binding for ops-provider lives in the
+      # embedded-outpost blueprint, which is the single binder for the embedded
+      # outpost across all forward-auth blueprints. See
+      # apps/prod/authentik/blueprints/embedded-outpost/.
       # The auth-gate Application: Application.provider is OneToOne, so exactly
       # one Application can link to ops-provider. This is it. Authentication
       # for every path on ops.${SECRET_DOMAIN} flows through this app.


### PR DESCRIPTION
Move the Authentik embedded outpost's provider binding out of the per-app
blueprints and into a single dedicated `embedded-outpost-blueprint` ConfigMap.
Per-app blueprints (today `ops`; next `prometheus` and `alertmanager`) now
own only their `ProxyProvider` and `Application`; they no longer mutate the
outpost.

- New ConfigMap `embedded-outpost-blueprint` is the only binder of the
embedded outpost. It lists providers by name via `!Find`, so per-app
blueprints can be added or removed without coordinating across files.
- `ops.blueprint.yaml` no longer carries an `authentik_outposts.outpost`
entry; a comment points to the new blueprint.
- Functional no-op for the running cluster: `ops-forward-auth` remains the
sole provider bound to the embedded outpost.
- Why one binder: the outpost's `providers` is a single M2M field that DRF
replaces (not merges) on each blueprint apply. Two blueprints binding the
same outpost would flap on every reconcile.
- Adding a forward-auth host now: new per-app blueprint dir + one `!Find`
line in `embedded-outpost.blueprint.yaml`.

---
**Stack**:
- #261
- #259 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*