### PR TITLE
feat(auth): authentik forward auth for prometheus and alertmanager

### DIFF
--- a/apps/base/prometheus/prometheus.hr.yaml
+++ b/apps/base/prometheus/prometheus.hr.yaml
@@ -43,7 +43,7 @@ spec:
       ingress:
         enabled: true
         annotations:
-          traefik.ingress.kubernetes.io/router.middlewares: default-forwardauth-authelia@kubernetescrd
+          traefik.ingress.kubernetes.io/router.middlewares: default-forwardauth-authentik@kubernetescrd
         pathType: Prefix
       config:
         global:
@@ -107,7 +107,7 @@ spec:
       ingress:
         enabled: true
         annotations:
-          traefik.ingress.kubernetes.io/router.middlewares: default-forwardauth-authelia@kubernetescrd
+          traefik.ingress.kubernetes.io/router.middlewares: default-forwardauth-authentik@kubernetescrd
         pathType: Prefix
       prometheusSpec:
         ruleSelectorNilUsesHelmValues: false

--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -46,6 +46,8 @@ spec:
       configMaps:
         - grafana-blueprint
         - ops-blueprint
+        - prometheus-blueprint
+        - alertmanager-blueprint
         - embedded-outpost-blueprint
     server:
       ingress:

--- a/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-blueprint
+  namespace: default
+data:
+  alertmanager.yaml: |
+    version: 1
+    metadata:
+      name: alertmanager-forward-auth
+    entries:
+      # Proxy provider for alert-manager.${SECRET_DOMAIN}.
+      # external_host MUST be domain-only (no trailing path) so
+      # set_oauth_defaults() generates a redirect_uri the embedded outpost
+      # actually sends back. urljoin drops trailing path segments otherwise.
+      - model: authentik_providers_proxy.proxyprovider
+        id: alertmanager-provider
+        identifiers:
+          name: alertmanager-forward-auth
+        attrs:
+          name: Alertmanager Forward Auth Provider
+          external_host: https://alert-manager.${SECRET_DOMAIN}
+          # internal_host is unused in forward_single mode but the serializer
+          # still needs a valid value. Use a placeholder.
+          internal_host: http://localhost
+          internal_host_ssl_validation: false
+          mode: forward_single
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # Application bound to the provider. Application.provider is OneToOne,
+      # so exactly one Application can link to alertmanager-provider.
+      - model: authentik_core.application
+        id: alertmanager-app
+        identifiers:
+          slug: alertmanager
+        attrs:
+          name: Alertmanager
+          slug: alertmanager
+          provider: !KeyOf alertmanager-provider
+          meta_launch_url: https://alert-manager.${SECRET_DOMAIN}/
+          meta_description: Alertmanager UI for Prometheus alerts
+          policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/alertmanager/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/alertmanager/kustomization.yaml
@@ -1,8 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafana
-  - ops
-  - prometheus
-  - alertmanager
-  - embedded-outpost
+  - alertmanager.blueprint.yaml

--- a/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
@@ -26,3 +26,5 @@ data:
         attrs:
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, ops-forward-auth]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-forward-auth]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-forward-auth]]

--- a/apps/prod/authentik/blueprints/prometheus/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/prometheus/kustomization.yaml
@@ -1,8 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafana
-  - ops
-  - prometheus
-  - alertmanager
-  - embedded-outpost
+  - prometheus.blueprint.yaml

--- a/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-blueprint
+  namespace: default
+data:
+  prometheus.yaml: |
+    version: 1
+    metadata:
+      name: prometheus-forward-auth
+    entries:
+      # Proxy provider for prometheus.${SECRET_DOMAIN}.
+      # external_host MUST be domain-only (no trailing path) so
+      # set_oauth_defaults() generates a redirect_uri the embedded outpost
+      # actually sends back. urljoin drops trailing path segments otherwise.
+      - model: authentik_providers_proxy.proxyprovider
+        id: prometheus-provider
+        identifiers:
+          name: prometheus-forward-auth
+        attrs:
+          name: Prometheus Forward Auth Provider
+          external_host: https://prometheus.${SECRET_DOMAIN}
+          # internal_host is unused in forward_single mode but the serializer
+          # still needs a valid value. Use a placeholder.
+          internal_host: http://localhost
+          internal_host_ssl_validation: false
+          mode: forward_single
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # Application bound to the provider. Application.provider is OneToOne,
+      # so exactly one Application can link to prometheus-provider.
+      - model: authentik_core.application
+        id: prometheus-app
+        identifiers:
+          slug: prometheus
+        attrs:
+          name: Prometheus
+          slug: prometheus
+          provider: !KeyOf prometheus-provider
+          meta_launch_url: https://prometheus.${SECRET_DOMAIN}/
+          meta_description: Prometheus metrics and query UI
+          policy_engine_mode: any

--- a/infrastructure/ingress/traefik/authentik.ingress.yaml
+++ b/infrastructure/ingress/traefik/authentik.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: authentik
 spec:
   routes:
-    - match: Host(`ops.${SECRET_DOMAIN}`) && PathPrefix(`/outpost.goauthentik.io`)
+    - match: (Host(`ops.${SECRET_DOMAIN}`) || Host(`prometheus.${SECRET_DOMAIN}`) || Host(`alert-manager.${SECRET_DOMAIN}`)) && PathPrefix(`/outpost.goauthentik.io`)
       kind: Rule
       services:
         - name: authentik-server


### PR DESCRIPTION
- `prometheus.${SECRET_DOMAIN}` and `alert-manager.${SECRET_DOMAIN}` now
require Authentik authentication. Both ingresses moved off Authelia
forward auth onto the existing `default/forwardauth-authentik` middleware.
- Authentik now exposes `prometheus` and `alertmanager` Applications (each
backed by its own forward-auth ProxyProvider) alongside the existing `ops`
setup. Each appears as a tile in the Authentik user library and
authenticates its host.
- The outpost-callback IngressRoute now matches all three protected hosts
so the OAuth callback path (`/outpost.goauthentik.io/*`) routes to
`authentik-server` on each.
- Authelia stack is still deployed but no longer used by any ingress —
separate cleanup to retire it.

---
**Stack**:
- #261 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*