### PR TITLE
feat(auth): add ops access group gating all authentik applications

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -49,6 +49,7 @@ spec:
         - prometheus-blueprint
         - alertmanager-blueprint
         - embedded-outpost-blueprint
+        - ops-group-blueprint
     server:
       ingress:
         hosts:

--- a/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
@@ -39,4 +39,5 @@ data:
           provider: !KeyOf alertmanager-provider
           meta_launch_url: https://alert-manager.${SECRET_DOMAIN}/
           meta_description: Alertmanager UI for Prometheus alerts
+          group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/grafana/grafana.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/grafana/grafana.blueprint.yaml
@@ -42,4 +42,5 @@ data:
           meta_launch_url: https://grafana.${SECRET_DOMAIN}
           meta_icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
           meta_description: Grafana Monitoring Dashboard
+          group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/groups/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/groups/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ops-group.blueprint.yaml

--- a/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-group-blueprint
+  namespace: default
+data:
+  ops-group.yaml: |
+    version: 1
+    metadata:
+      name: ops-access-group
+    entries:
+      # state: created -> the worker creates this group ONCE with akadmin as
+      # the seed member and never reconciles it again. Members added or
+      # removed via the authentik UI thereafter survive every blueprint
+      # re-apply. Renaming the group or flipping is_superuser will require
+      # deleting it manually first.
+      # https://docs.goauthentik.io/customize/blueprints/v1/structure/
+      - model: authentik_core.group
+        id: ops-group
+        state: created
+        identifiers:
+          name: Ops
+        attrs:
+          is_superuser: false
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+      # PolicyBindings stay state: present (default) so this file is the
+      # authoritative source for "which apps does the Ops group gate?".
+      # Removing a binding requires setting state: absent here, NOT just
+      # deleting the entry — authentik does not prune unmanaged bindings.
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, grafana]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, ops]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, longhorn]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, weave-gitops]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, traefik-dashboard]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, prometheus]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, alertmanager]]
+          group: !KeyOf ops-group
+          order: 0
+        attrs:
+          enabled: true

--- a/apps/prod/authentik/blueprints/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - prometheus
   - alertmanager
   - embedded-outpost
+  - groups

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -43,6 +43,7 @@ data:
           provider: !KeyOf ops-provider
           meta_launch_url: https://ops.${SECRET_DOMAIN}/
           meta_description: Auth gate for ops.${SECRET_DOMAIN} (Longhorn, Weave, Traefik)
+          group: Ops
           policy_engine_mode: any
       # Tile-only Applications: no provider, just deep-link launchers in the
       # user library. Forward-auth on each path still goes through ops-provider
@@ -57,6 +58,7 @@ data:
           meta_launch_url: https://ops.${SECRET_DOMAIN}/longhorn
           meta_icon: https://raw.githubusercontent.com/longhorn/longhorn-ui/master/src/assets/images/longhorn-logo.svg
           meta_description: Longhorn Storage Management UI
+          group: Ops
           policy_engine_mode: any
       - model: authentik_core.application
         id: weave-app
@@ -67,6 +69,7 @@ data:
           slug: weave-gitops
           meta_launch_url: https://ops.${SECRET_DOMAIN}/weave
           meta_description: Flux GitOps Dashboard
+          group: Ops
           policy_engine_mode: any
       - model: authentik_core.application
         id: traefik-app
@@ -77,4 +80,5 @@ data:
           slug: traefik-dashboard
           meta_launch_url: https://ops.${SECRET_DOMAIN}/dashboard/
           meta_description: Traefik Reverse Proxy Dashboard
+          group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
@@ -39,4 +39,5 @@ data:
           provider: !KeyOf prometheus-provider
           meta_launch_url: https://prometheus.${SECRET_DOMAIN}/
           meta_description: Prometheus metrics and query UI
+          group: Ops
           policy_engine_mode: any


### PR DESCRIPTION
- Introduces an `Ops` group in authentik and a `PolicyBinding` per
Application requiring Ops membership for access. Before this change,
every authenticated authentik user could reach every app (zero
PolicyBindings existed). After, only Ops members can reach Grafana,
the `ops.${SECRET_DOMAIN}` auth-gate, Prometheus, Alertmanager, and
the Longhorn / Weave GitOps / Traefik library tiles. Authentik
superusers do NOT bypass PolicyBindings.
- Seeds `akadmin` into Ops at first creation via `state: created`, so
the bootstrap account does not lose access during rollout. Membership
changes made through the authentik UI thereafter survive every
blueprint re-apply -- the group entry is created once and never
reconciled.
- Sets the cosmetic `Application.group: Ops` string on every
Application so the seven apps cluster under a single "Ops" header
in the user library.
- Establishes a `blueprints/groups/` subdirectory and the convention
of one file per access group (group definition + its PolicyBindings
co-located in a single blueprint), so adding a future group is a
new file rather than edits scattered across per-app blueprints.

---
**Stack**:
- #263 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*