### PR TITLE
chore(auth): move authentik to OAUTH_URL and retire auth2

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -53,4 +53,4 @@ spec:
     server:
       ingress:
         hosts:
-          - auth2.${SECRET_DOMAIN}
+          - ${OAUTH_URL}

--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -41,10 +41,10 @@ spec:
         GF_AUTH_GENERIC_OAUTH_NAME: "authentik"
         GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "grafana"
         GF_AUTH_GENERIC_OAUTH_SCOPES: "openid profile email"
-        GF_AUTH_GENERIC_OAUTH_AUTH_URL: "https://auth2.${SECRET_DOMAIN}/application/o/authorize/"
-        GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "https://auth2.${SECRET_DOMAIN}/application/o/token/"
-        GF_AUTH_GENERIC_OAUTH_API_URL: "https://auth2.${SECRET_DOMAIN}/application/o/userinfo/"
-        GF_AUTH_SIGNOUT_REDIRECT_URL: "https://auth2.${SECRET_DOMAIN}/application/o/grafana/end-session/"
+        GF_AUTH_GENERIC_OAUTH_AUTH_URL: "https://${OAUTH_URL}/application/o/authorize/"
+        GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "https://${OAUTH_URL}/application/o/token/"
+        GF_AUTH_GENERIC_OAUTH_API_URL: "https://${OAUTH_URL}/application/o/userinfo/"
+        GF_AUTH_SIGNOUT_REDIRECT_URL: "https://${OAUTH_URL}/application/o/grafana/end-session/"
         # Optionally enable auto-login (bypasses Grafana login screen)
         GF_AUTH_OAUTH_AUTO_LOGIN: "true"
         # Optionally map user groups to Grafana roles

--- a/configs/prod/cluster-secrets.sops.yaml
+++ b/configs/prod/cluster-secrets.sops.yaml
@@ -10,6 +10,7 @@ stringData:
     SECRET_DOMAIN_HJP_ORG: ENC[AES256_GCM,data:FAKHI8qdx0yNW0RbOuxjsw==,iv:hBuvC/4ockgckSo88DbsmUNwmBZFyD7b+pXQ6C7Zq1c=,tag:lAkBY1xk+IdV2EXp/Kytuw==,type:str]
     SECRET_DOMAIN_HJP_COM: ENC[AES256_GCM,data:KowLFspLEYTBQLzBNeGASA==,iv:9lHPRIETpN1GVCfmbpM4qWnq6+aMdpdKexTNWcitKIg=,tag:WFJtsRrgYpcXtEfzkdpW/w==,type:str]
     SECRET_DOMAIN_HJP_US: ENC[AES256_GCM,data:RIdEmcURbg==,iv:ZwMNNpv8v3JxaXvLF1j31SBiCZrt+f1DXhKVePRbzLA=,tag:gEGZofglFqniF6jo28H0+Q==,type:str]
+    OAUTH_URL: ENC[AES256_GCM,data:gN6vEG9n9HcT31pN3SNpHw==,iv:ye3/nuKiRYR+RGf3vKafH6BEb87XCtmwNax+LBvwFts=,tag:AsGn++yXAcb8lgBMS6wMYg==,type:str]
     #ENC[AES256_GCM,data:GxkE4bIHyojg,iv:ZqcX/RtDKvN7d+njRvuGtUr1A2SzNwu23U92Sz4UFNY=,tag:YHJlrsZw0V/ezLhKMTJfgg==,type:comment]
     EMAIL: ENC[AES256_GCM,data:YzQeKG7JA+N5BAClECfEiM26JQ==,iv:IFBR6s9boGD4fJd9FYfyjrgOYEI1CWUtfe35+DHCYhA=,tag:caVp8/Cbk0q1zd/O7GkdIQ==,type:str]
     ADMIN_USERNAME: ENC[AES256_GCM,data:bzarstRymw==,iv:qqNCOrktJLZSX4313qSBwe1QNmUy0o8zdq7Gkk4g5Uo=,tag:NncQnCPpKHo6FP+dPhvI0w==,type:str]
@@ -35,8 +36,8 @@ stringData:
     VELERO_B2_BUCKET: ENC[AES256_GCM,data:ZlZ9VAM6//OYPPKFE+ftK9cvsjChvMVDcQ==,iv:o4spyrlhkyPYrzlrK2zCDcpT5oH6NSbMc9oBQopt2cQ=,tag:LNZIfnh0ny5X6oBuxhTsYg==,type:str]
     VELERO_B2_ENDPOINT: ENC[AES256_GCM,data:WPEXjA4pA1RkOdF+d/t0gAvrTW25qFK0pIfXhmQlCV1rJj8PmuQ=,iv:NXfeHRQCS53CDk/EVYzLsO+F/cYB8lp2FoSJCIb3kg8=,tag:A3Yigzc6QNsVGzc//NRt1Q==,type:str]
 sops:
-    lastmodified: "2026-04-10T00:21:35Z"
-    mac: ENC[AES256_GCM,data:hl43ziXdP912Ym8PbJAnA3pOBSbTnnFpFvRraED0mlmMJpKLplI40XcFggBbri+JsUUoOx7IYzC/JRVT2tnDMBWOjSWUa6beX8Hcoj10ZkBYNWYiqE5ufC/sviCfL6MM/w/AOiVPOba3jqohfhizD4Qy43JZtE/Px30Kb3x55D4=,iv:zuXT1oB18IE5THGfgGAN8ri8vvV6cN1anc4DJibF2YM=,tag:DV6pvnx4WzUQxMHjEFCuvw==,type:str]
+    lastmodified: "2026-05-04T02:45:57Z"
+    mac: ENC[AES256_GCM,data:8dWxjGs9DKKxgnYqp/IzHte8a1rI+IpCthRI8GXFijrcU+0YQHOqqLFyI1gqShFYsv007o3OhiCL82Mc2sMSWYZoFqxoLdcgR89dTTOkw9qaE/7OcPyrOhBOpkAXjDUlp7acfFxoqtejsq9+7v+/csKMWvIX+umDjktogDTZnyw=,iv:AseEkMayvRarx6GxWqoHx0GnqUYY5U/v5g9LLa38IWc=,tag:ox7UqdKuqjEFscoZ9XxjiA==,type:str]
     pgp:
         - created_at: "2025-12-10T00:36:44Z"
           enc: |-
@@ -59,4 +60,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
     encrypted_regex: ^(data|stringData)$
-    version: 3.11.0
+    version: 3.12.2


### PR DESCRIPTION
- Adds OAUTH_URL (bare hostname) to cluster-secrets so the authentik
IdP location is no longer pasted across HelmReleases. Consumers
prepend `https://` when they need a full URL.
- Authentik ingress host moves from `auth2.${SECRET_DOMAIN}` to
`${OAUTH_URL}`. Traefik will issue a fresh Let's Encrypt cert for
the new hostname (~30-60s ACME window during cutover).
- Grafana's four GF_AUTH_GENERIC_OAUTH_* URLs now reference
`https://${OAUTH_URL}/application/o/...` instead of hard-coding
the auth2 host.
- `auth2.${SECRET_DOMAIN}` no longer appears anywhere in the repo;
the leftover suffix from the Authelia transition is gone.

---
**Stack**:
- #264 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*