### PR TITLE
chore(auth): add tile icons for authentik applications

### DIFF
--- a/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/alertmanager/alertmanager.blueprint.yaml
@@ -38,6 +38,8 @@ data:
           slug: alertmanager
           provider: !KeyOf alertmanager-provider
           meta_launch_url: https://alert-manager.${SECRET_DOMAIN}/
+          meta_icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/prometheus/icon/color/prometheus-icon-color.svg
           meta_description: Alertmanager UI for Prometheus alerts
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/grafana/grafana.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/grafana/grafana.blueprint.yaml
@@ -42,5 +42,6 @@ data:
           meta_launch_url: https://grafana.${SECRET_DOMAIN}
           meta_icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
           meta_description: Grafana Monitoring Dashboard
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -43,6 +43,7 @@ data:
           provider: !KeyOf ops-provider
           meta_launch_url: https://ops.${SECRET_DOMAIN}/
           meta_description: Auth gate for ops.${SECRET_DOMAIN} (Longhorn, Weave, Traefik)
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
       # Tile-only Applications: no provider, just deep-link launchers in the
@@ -58,6 +59,7 @@ data:
           meta_launch_url: https://ops.${SECRET_DOMAIN}/longhorn
           meta_icon: https://raw.githubusercontent.com/longhorn/longhorn-ui/master/src/assets/images/longhorn-logo.svg
           meta_description: Longhorn Storage Management UI
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
       - model: authentik_core.application
@@ -68,7 +70,9 @@ data:
           name: Weave GitOps
           slug: weave-gitops
           meta_launch_url: https://ops.${SECRET_DOMAIN}/weave
+          meta_icon: https://raw.githubusercontent.com/weaveworks/weave-gitops/main/website/static/img/logo.svg
           meta_description: Flux GitOps Dashboard
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
       - model: authentik_core.application
@@ -79,6 +83,8 @@ data:
           name: Traefik Dashboard
           slug: traefik-dashboard
           meta_launch_url: https://ops.${SECRET_DOMAIN}/dashboard/
+          meta_icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefikproxy-icon-color.png
           meta_description: Traefik Reverse Proxy Dashboard
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/prometheus/prometheus.blueprint.yaml
@@ -38,6 +38,8 @@ data:
           slug: prometheus
           provider: !KeyOf prometheus-provider
           meta_launch_url: https://prometheus.${SECRET_DOMAIN}/
+          meta_icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/prometheus/icon/color/prometheus-icon-color.svg
           meta_description: Prometheus metrics and query UI
+          open_in_new_tab: true
           group: Ops
           policy_engine_mode: any


### PR DESCRIPTION
Each authentik application tile now renders the upstream project logo
instead of the default placeholder. Alertmanager reuses the Prometheus
logo (no upstream alertmanager-specific icon exists); the ops auth-gate
Application is left without an icon since it is not a user-launchable
tile.

---
**Stack**:
- #265 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*