### PR TITLE
bugfix(auth): fix ops access group blueprint apply error

### DIFF
--- a/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
@@ -9,12 +9,6 @@ data:
     metadata:
       name: ops-access-group
     entries:
-      # state: created -> the worker creates this group ONCE with akadmin as
-      # the seed member and never reconciles it again. Members added or
-      # removed via the authentik UI thereafter survive every blueprint
-      # re-apply. Renaming the group or flipping is_superuser will require
-      # deleting it manually first.
-      # https://docs.goauthentik.io/customize/blueprints/v1/structure/
       - model: authentik_core.group
         id: ops-group
         state: created
@@ -22,12 +16,6 @@ data:
           name: Ops
         attrs:
           is_superuser: false
-          users:
-            - !Find [authentik_core.user, [username, akadmin]]
-      # PolicyBindings stay state: present (default) so this file is the
-      # authoritative source for "which apps does the Ops group gate?".
-      # Removing a binding requires setting state: absent here, NOT just
-      # deleting the entry — authentik does not prune unmanaged bindings.
       - model: authentik_policies.policybinding
         identifiers:
           target: !Find [authentik_core.application, [slug, grafana]]

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -9,9 +9,6 @@ data:
     metadata:
       name: ops-forward-auth
     entries:
-      # Single Proxy Provider for the entire ops.${SECRET_DOMAIN} host.
-      # external_host MUST be domain-only (no path) so set_oauth_defaults()
-      # generates a redirect_uri the embedded outpost actually sends back.
       - model: authentik_providers_proxy.proxyprovider
         id: ops-provider
         identifiers:
@@ -19,20 +16,12 @@ data:
         attrs:
           name: Ops Forward Auth Provider
           external_host: https://ops.${SECRET_DOMAIN}
-          # internal_host is unused in forward_single mode but the serializer
-          # still needs a valid value. Use a placeholder.
+          # internal_host is unused in forward_single mode but required by the serializer.
           internal_host: http://localhost
           internal_host_ssl_validation: false
           mode: forward_single
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-      # The embedded outpost binding for ops-provider lives in the
-      # embedded-outpost blueprint, which is the single binder for the embedded
-      # outpost across all forward-auth blueprints. See
-      # apps/prod/authentik/blueprints/embedded-outpost/.
-      # The auth-gate Application: Application.provider is OneToOne, so exactly
-      # one Application can link to ops-provider. This is it. Authentication
-      # for every path on ops.${SECRET_DOMAIN} flows through this app.
       - model: authentik_core.application
         id: ops-app
         identifiers:
@@ -46,9 +35,7 @@ data:
           open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
-      # Tile-only Applications: no provider, just deep-link launchers in the
-      # user library. Forward-auth on each path still goes through ops-provider
-      # (Traefik middleware), so these are protected just by virtue of the host.
+      # Tile-only Applications: deep-link launchers in the user library; protection comes from the host-level forward-auth above.
       - model: authentik_core.application
         id: longhorn-app
         identifiers:


### PR DESCRIPTION
### Description

- The Ops access gating introduced in #263 was a silent no-op. The `ops-access-group` blueprint failed serializer validation because its seed user reference `!Find [authentik_core.user, [username, akadmin]]` returned `None` — no `akadmin` exists in this instance — and the resulting `Invalid pk "None"` error cascaded to all 7 PolicyBindings (they `!KeyOf` the never-built group). Net effect: `BlueprintInstance.status=error`, no `Ops` group, no PolicyBindings, every authenticated user could reach grafana/prometheus/alertmanager/ops/longhorn/weave-gitops/traefik-dashboard. Drops the `users:` seed list; the group is now created empty (`state: created`) and membership is managed in the Authentik UI thereafter.
- **Operational note for rollout:** after first apply, the admin must be added to `Ops` in the UI **before** the PolicyBindings will allow access — there is a brief window where the 7 gated apps deny everyone (Authentik admin itself is not gated, so self-recovery via UI works).
- Strips migration/state-mechanic comments from `ops-group.blueprint.yaml` and `ops/ops.blueprint.yaml`; keeps only short purpose-describing comments.
- Updates the Longhorn tile icon to longhorn.io's official asset URL (more stable than the prior `raw.githubusercontent.com` link).

---
**Stack**:
- #267 ⬅
- #266
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*