### PR TITLE
feat(backup): include authentik DB in cnpg pg_dump rotation

### DIFF
--- a/infrastructure/backup/README.md
+++ b/infrastructure/backup/README.md
@@ -11,6 +11,7 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  • kutt-postgresql-cnpg                                                     │
 │  • plausible-postgresql-cnpg                                                │
+│  • authentik-postgresql-cnpg                                                │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -28,12 +29,12 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 │  │                         Image: postgres:16-alpine                    │  │
 │  └───────────────────────────────────┬──────────────────────────────────┘  │
 │                                      │                                      │
-│                      ┌──────────────┴──────────────┐                       │
-│                      ▼                             ▼                       │
-│            ┌──────────────────┐           ┌──────────────────┐              │
-│            │  kutt-pg-cnpg    │           │plausible-pg-cnpg │              │
-│            │   Port 5432      │           │   Port 5432      │              │
-│            └──────────────────┘           └──────────────────┘              │
+│              ┌───────────────────────┼───────────────────────┐              │
+│              ▼                       ▼                       ▼              │
+│   ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐      │
+│   │  kutt-pg-cnpg    │    │plausible-pg-cnpg │    │authentik-pg-cnpg │      │
+│   │   Port 5432      │    │   Port 5432      │    │   Port 5432      │      │
+│   └──────────────────┘    └──────────────────┘    └──────────────────┘      │
 │                                      │                                      │
 │                                      ▼                                      │
 │  ┌──────────────────────────────────────────────────────────────────────┐  │
@@ -45,7 +46,9 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 │  │    ├── kutt/                                                         │  │
 │  │    │   ├── kutt-20241226-140000.dump                                 │  │
 │  │    │   └── ...                                                       │  │
-│  │    └── plausible/                                                    │  │
+│  │    ├── plausible/                                                    │  │
+│  │    │   └── ...                                                       │  │
+│  │    └── authentik/                                                    │  │
 │  │        └── ...                                                       │  │
 │  └──────────────────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -75,8 +78,13 @@ Now                    12h ago              48h ago                    7d ago
  └────────────────────────┴────────────────────┴──────────────────────────┘
 
 Maximum backups per database: 15
-Total across all databases: 30 dump files
+Total across all databases: 45 dump files
 ```
+
+> **PVC headroom:** the 15Gi PVC was sized for two databases. Authentik dumps
+> are typically small (tens of MB), but verify free space after the first full
+> retention cycle (`kubectl exec`/`df` against `cnpg-backups-pvc`) and bump
+> `cnpg-backup.pvc.yaml` if utilisation exceeds ~70%.
 
 ## Storage
 
@@ -120,6 +128,7 @@ The backup job is isolated via NetworkPolicy:
 │    ✅ PostgreSQL clusters on port 5432:                                     │
 │       - kutt-postgresql-cnpg-cluster                                        │
 │       - plausible-postgresql-cnpg-cluster                                   │
+│       - authentik-postgresql-cnpg-cluster                                   │
 │    ❌ All other traffic denied                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/infrastructure/backup/cnpg-backup.cronjob.yaml
+++ b/infrastructure/backup/cnpg-backup.cronjob.yaml
@@ -130,7 +130,7 @@ spec:
                   }
 
                   # Create backup directories if they don't exist
-                  mkdir -p /backups/kutt /backups/plausible
+                  mkdir -p /backups/kutt /backups/plausible /backups/authentik
 
                   # Backup kutt
                   echo "Backing up kutt..."
@@ -152,10 +152,21 @@ spec:
                     -f /backups/plausible/plausible-$${DATE}.dump
                   echo "Plausible backup complete: plausible-$${DATE}.dump"
 
+                  # Backup authentik
+                  echo "Backing up authentik..."
+                  PGPASSWORD=$$(cat /secrets/authentik/password) pg_dump \
+                    -h authentik-postgresql-cnpg-cluster-rw \
+                    -U authentik \
+                    -d authentik \
+                    -Fc \
+                    -f /backups/authentik/authentik-$${DATE}.dump
+                  echo "Authentik backup complete: authentik-$${DATE}.dump"
+
                   # Apply retention policy
                   echo "Applying retention policy..."
                   cleanup_backups /backups/kutt kutt
                   cleanup_backups /backups/plausible plausible
+                  cleanup_backups /backups/authentik authentik
 
                   # List current backups
                   echo ""
@@ -173,6 +184,9 @@ spec:
                 - name: plausible-secrets
                   mountPath: /secrets/plausible
                   readOnly: true
+                - name: authentik-secrets
+                  mountPath: /secrets/authentik
+                  readOnly: true
           restartPolicy: OnFailure
           volumes:
             - name: backups
@@ -188,6 +202,12 @@ spec:
             - name: plausible-secrets
               secret:
                 secretName: plausible-secrets
+                items:
+                  - key: password
+                    path: password
+            - name: authentik-secrets
+              secret:
+                secretName: authentik-secrets
                 items:
                   - key: password
                     path: password

--- a/infrastructure/backup/cnpg-backup.networkpolicy.yaml
+++ b/infrastructure/backup/cnpg-backup.networkpolicy.yaml
@@ -28,6 +28,9 @@ spec:
         - podSelector:
             matchLabels:
               cnpg.io/cluster: plausible-postgresql-cnpg-cluster
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: authentik-postgresql-cnpg-cluster
       ports:
         - protocol: TCP
           port: 5432


### PR DESCRIPTION
## Summary

- Adds the `authentik-postgresql-cnpg` cluster to the every-2-hours `cnpg-pg-dump-backup` CronJob alongside `kutt` and `plausible`.
- Extends the backup `NetworkPolicy` egress allowlist to permit port 5432 to the authentik cluster pods.
- Updates `infrastructure/backup/README.md` (overview, architecture, retention math, network section) and adds a PVC-headroom callout to monitor after the first full retention cycle.

## Why

Authentik upgrades migrate the schema in non-reversible ways. Today there is no logical (pg_dump) restore path for the authentik database — only a Velero filesystem backup of the Longhorn PVC, which is not reliable for a live Postgres. This PR closes that gap before the upgrade work begins. Total backup count moves from 30 → 45 dumps; PVC stays at 15Gi for now.

## Test plan

- [ ] CI green (manifest lint / kustomize build)
- [ ] After Flux reconciles, trigger a manual run: `kubectl create job --from=cronjob/cnpg-pg-dump-backup cnpg-backup-pre-upgrade -n default`
- [ ] Confirm logs show all three databases dumped successfully
- [ ] Inspect PVC: `/backups/authentik/authentik-<timestamp>.dump` exists and is non-empty
- [ ] Confirm NetworkPolicy didn't break existing kutt/plausible dumps in the same run