### PR TITLE
feat(backup): include authentik database in cnpg pg_dump rotation

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -33,6 +33,7 @@ spec:
   values:
     global:
       image:
+        repository: ghcr.io/goauthentik/server
         tag: 2025.10.3
       envFrom:
         - secretRef:

--- a/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/ops-group.blueprint.yaml
@@ -9,12 +9,6 @@ data:
     metadata:
       name: ops-access-group
     entries:
-      # state: created -> the worker creates this group ONCE with akadmin as
-      # the seed member and never reconciles it again. Members added or
-      # removed via the authentik UI thereafter survive every blueprint
-      # re-apply. Renaming the group or flipping is_superuser will require
-      # deleting it manually first.
-      # https://docs.goauthentik.io/customize/blueprints/v1/structure/
       - model: authentik_core.group
         id: ops-group
         state: created
@@ -22,12 +16,6 @@ data:
           name: Ops
         attrs:
           is_superuser: false
-          users:
-            - !Find [authentik_core.user, [username, akadmin]]
-      # PolicyBindings stay state: present (default) so this file is the
-      # authoritative source for "which apps does the Ops group gate?".
-      # Removing a binding requires setting state: absent here, NOT just
-      # deleting the entry — authentik does not prune unmanaged bindings.
       - model: authentik_policies.policybinding
         identifiers:
           target: !Find [authentik_core.application, [slug, grafana]]

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -9,9 +9,6 @@ data:
     metadata:
       name: ops-forward-auth
     entries:
-      # Single Proxy Provider for the entire ops.${SECRET_DOMAIN} host.
-      # external_host MUST be domain-only (no path) so set_oauth_defaults()
-      # generates a redirect_uri the embedded outpost actually sends back.
       - model: authentik_providers_proxy.proxyprovider
         id: ops-provider
         identifiers:
@@ -19,20 +16,12 @@ data:
         attrs:
           name: Ops Forward Auth Provider
           external_host: https://ops.${SECRET_DOMAIN}
-          # internal_host is unused in forward_single mode but the serializer
-          # still needs a valid value. Use a placeholder.
+          # internal_host is unused in forward_single mode but required by the serializer.
           internal_host: http://localhost
           internal_host_ssl_validation: false
           mode: forward_single
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-      # The embedded outpost binding for ops-provider lives in the
-      # embedded-outpost blueprint, which is the single binder for the embedded
-      # outpost across all forward-auth blueprints. See
-      # apps/prod/authentik/blueprints/embedded-outpost/.
-      # The auth-gate Application: Application.provider is OneToOne, so exactly
-      # one Application can link to ops-provider. This is it. Authentication
-      # for every path on ops.${SECRET_DOMAIN} flows through this app.
       - model: authentik_core.application
         id: ops-app
         identifiers:
@@ -46,9 +35,7 @@ data:
           open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
-      # Tile-only Applications: no provider, just deep-link launchers in the
-      # user library. Forward-auth on each path still goes through ops-provider
-      # (Traefik middleware), so these are protected just by virtue of the host.
+      # Tile-only Applications: deep-link launchers in the user library; protection comes from the host-level forward-auth above.
       - model: authentik_core.application
         id: longhorn-app
         identifiers:

--- a/infrastructure/backup/README.md
+++ b/infrastructure/backup/README.md
@@ -11,6 +11,7 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  • kutt-postgresql-cnpg                                                     │
 │  • plausible-postgresql-cnpg                                                │
+│  • authentik-postgresql-cnpg                                                │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -28,12 +29,12 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 │  │                         Image: postgres:16-alpine                    │  │
 │  └───────────────────────────────────┬──────────────────────────────────┘  │
 │                                      │                                      │
-│                      ┌──────────────┴──────────────┐                       │
-│                      ▼                             ▼                       │
-│            ┌──────────────────┐           ┌──────────────────┐              │
-│            │  kutt-pg-cnpg    │           │plausible-pg-cnpg │              │
-│            │   Port 5432      │           │   Port 5432      │              │
-│            └──────────────────┘           └──────────────────┘              │
+│              ┌───────────────────────┼───────────────────────┐              │
+│              ▼                       ▼                       ▼              │
+│   ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐      │
+│   │  kutt-pg-cnpg    │    │plausible-pg-cnpg │    │authentik-pg-cnpg │      │
+│   │   Port 5432      │    │   Port 5432      │    │   Port 5432      │      │
+│   └──────────────────┘    └──────────────────┘    └──────────────────┘      │
 │                                      │                                      │
 │                                      ▼                                      │
 │  ┌──────────────────────────────────────────────────────────────────────┐  │
@@ -45,7 +46,9 @@ This directory contains backup configurations for CloudNativePG PostgreSQL datab
 │  │    ├── kutt/                                                         │  │
 │  │    │   ├── kutt-20241226-140000.dump                                 │  │
 │  │    │   └── ...                                                       │  │
-│  │    └── plausible/                                                    │  │
+│  │    ├── plausible/                                                    │  │
+│  │    │   └── ...                                                       │  │
+│  │    └── authentik/                                                    │  │
 │  │        └── ...                                                       │  │
 │  └──────────────────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -75,8 +78,13 @@ Now                    12h ago              48h ago                    7d ago
  └────────────────────────┴────────────────────┴──────────────────────────┘
 
 Maximum backups per database: 15
-Total across all databases: 30 dump files
+Total across all databases: 45 dump files
 ```
+
+> **PVC headroom:** the 15Gi PVC was sized for two databases. Authentik dumps
+> are typically small (tens of MB), but verify free space after the first full
+> retention cycle (`kubectl exec`/`df` against `cnpg-backups-pvc`) and bump
+> `cnpg-backup.pvc.yaml` if utilisation exceeds ~70%.
 
 ## Storage
 
@@ -120,6 +128,7 @@ The backup job is isolated via NetworkPolicy:
 │    ✅ PostgreSQL clusters on port 5432:                                     │
 │       - kutt-postgresql-cnpg-cluster                                        │
 │       - plausible-postgresql-cnpg-cluster                                   │
+│       - authentik-postgresql-cnpg-cluster                                   │
 │    ❌ All other traffic denied                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/infrastructure/backup/cnpg-backup.cronjob.yaml
+++ b/infrastructure/backup/cnpg-backup.cronjob.yaml
@@ -130,7 +130,7 @@ spec:
                   }
 
                   # Create backup directories if they don't exist
-                  mkdir -p /backups/kutt /backups/plausible
+                  mkdir -p /backups/kutt /backups/plausible /backups/authentik
 
                   # Backup kutt
                   echo "Backing up kutt..."
@@ -152,10 +152,21 @@ spec:
                     -f /backups/plausible/plausible-$${DATE}.dump
                   echo "Plausible backup complete: plausible-$${DATE}.dump"
 
+                  # Backup authentik
+                  echo "Backing up authentik..."
+                  PGPASSWORD=$$(cat /secrets/authentik/password) pg_dump \
+                    -h authentik-postgresql-cnpg-cluster-rw \
+                    -U authentik \
+                    -d authentik \
+                    -Fc \
+                    -f /backups/authentik/authentik-$${DATE}.dump
+                  echo "Authentik backup complete: authentik-$${DATE}.dump"
+
                   # Apply retention policy
                   echo "Applying retention policy..."
                   cleanup_backups /backups/kutt kutt
                   cleanup_backups /backups/plausible plausible
+                  cleanup_backups /backups/authentik authentik
 
                   # List current backups
                   echo ""
@@ -173,6 +184,9 @@ spec:
                 - name: plausible-secrets
                   mountPath: /secrets/plausible
                   readOnly: true
+                - name: authentik-secrets
+                  mountPath: /secrets/authentik
+                  readOnly: true
           restartPolicy: OnFailure
           volumes:
             - name: backups
@@ -188,6 +202,12 @@ spec:
             - name: plausible-secrets
               secret:
                 secretName: plausible-secrets
+                items:
+                  - key: password
+                    path: password
+            - name: authentik-secrets
+              secret:
+                secretName: authentik-secrets
                 items:
                   - key: password
                     path: password

--- a/infrastructure/backup/cnpg-backup.networkpolicy.yaml
+++ b/infrastructure/backup/cnpg-backup.networkpolicy.yaml
@@ -28,6 +28,9 @@ spec:
         - podSelector:
             matchLabels:
               cnpg.io/cluster: plausible-postgresql-cnpg-cluster
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: authentik-postgresql-cnpg-cluster
       ports:
         - protocol: TCP
           port: 5432


### PR DESCRIPTION
Authentik upgrades are not reversible at the schema level; we need a
logical pg_dump for the authentik DB before any version bump. The
existing CronJob only covers kutt and plausible, leaving authentik
without a restore path. Extend the CronJob, NetworkPolicy egress
allowlist, and README to include the authentik-postgresql-cnpg cluster
alongside kutt/plausible. PVC stays at 15Gi; README flags the headroom
to monitor after the first full retention cycle.

---
**Stack**:
- #271 ⬅
- #270
- #268
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*