### PR TITLE
chore(auth): upgrade authentik to 2025.12.4

### DIFF
--- a/apps/base/authentik/authentik.hr.yaml
+++ b/apps/base/authentik/authentik.hr.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: 2025.10.3
+      version: 2025.12.4
       sourceRef:
         kind: HelmRepository
         name: authentik-charts

--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -34,7 +34,7 @@ spec:
     global:
       image:
         repository: ghcr.io/goauthentik/server
-        tag: 2025.10.3
+        tag: 2025.12.4
       envFrom:
         - secretRef:
             name: grafana-auth-secrets


### PR DESCRIPTION
## Summary

- Bumps the authentik Helm chart from `2025.10.3` → `2025.12.4` in `apps/base/authentik/authentik.hr.yaml`
- Bumps the prod image tag from `2025.10.3` → `2025.12.4` in `apps/prod/authentik/authentik.hr.yaml` to match
- First of two sequential hops on the way to 2026.2.2 (Authentik disallows skipping major versions)

## Why

2025.12 introduces the RBAC overhaul: group-name uniqueness is now enforced at the DB layer, permission inheritance flows through ancestor groups, and direct user-permission relationships are deprecated in favor of roles. The 2025.12 → 2026.2 hop adds `User.ak_groups` deprecation, SCIM filter rename, and certificate-detail storage migration — needs its own bake before being applied.

### Breaking-change exposure (full audit in plan)

- `Group.parent` → `Group.parents` M2M: not used by our blueprints
- Direct user permissions: not assigned by any blueprint
- Icon API endpoints removed: blueprints use literal `icon:` URL strings, not the API
- `/media` → `/files` path move: chart-internal; Traefik `IngressRoute` only matches `/outpost.goauthentik.io/*`
- Group name uniqueness migration: pre-flight check against the live DB before merge — see test plan

## Test plan

- [ ] Pre-flight: confirm no duplicate group names in the running Authentik DB:
  ```bash
  curl -sH "Authorization: Bearer $TOKEN" \
    https://${OAUTH_URL}/api/v3/core/groups/?page_size=1000 \
    | jq -r '.results[].name' | sort | uniq -d
  ```
  Output must be empty.
- [ ] Pre-flight: confirm a fresh authentik pg_dump exists in `cnpg-backups-pvc` (PR #271 enabled this).
- [ ] Pre-flight: snapshot current pod images for rollback reference: `kubectl get pods -n default -l app.kubernetes.io/name=authentik -o jsonpath='{.items[*].spec.containers[*].image}'`
- [ ] CI green
- [ ] After merge: `flux reconcile source helm authentik-charts -n default && flux reconcile helmrelease authentik -n default --with-source`
- [ ] `kubectl rollout status deploy/authentik-server deploy/authentik-worker -n default` succeeds
- [ ] `kubectl logs deploy/authentik-worker -n default --tail=200` shows blueprint apply messages, no `migration inconsistency` errors
- [ ] All `BlueprintInstance` resources are `successful`
- [ ] Login at `https://${OAUTH_URL}` works (OIDC for Grafana)
- [ ] Forward-auth gate works for: `ops`, `prometheus`, `alert-manager`, `longhorn`, `weave`, `traefik` dashboard
- [ ] Application tile icons still render in the user library
- [ ] Embedded outpost shows version `2025.12.4` in admin → Outposts
- [ ] No new `Configuration warning` events in admin → Events

## Rollback

Authentik does not support downgrading. If validation fails: `git revert` this commit, then `pg_restore` the most recent pre-upgrade dump from `cnpg-backups-pvc:/backups/authentik/` (procedure in [backup README](../tree/main/infrastructure/backup/README.md) and the upgrade plan).