### PR TITLE
chore(auth): upgrade authentik to 2026.2.2

### DIFF
--- a/apps/base/authentik/authentik.hr.yaml
+++ b/apps/base/authentik/authentik.hr.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: 2025.12.4
+      version: 2026.2.2
       sourceRef:
         kind: HelmRepository
         name: authentik-charts

--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -34,7 +34,7 @@ spec:
     global:
       image:
         repository: ghcr.io/goauthentik/server
-        tag: 2025.12.4
+        tag: 2026.2.2
       envFrom:
         - secretRef:
             name: grafana-auth-secrets


### PR DESCRIPTION
## Summary

- Bumps the authentik Helm chart from `2025.12.4` → `2026.2.2` in `apps/base/authentik/authentik.hr.yaml`
- Bumps the prod image tag from `2025.12.4` → `2026.2.2` in `apps/prod/authentik/authentik.hr.yaml` to match
- Second of two sequential hops, completing the path from 2025.10.3 to the latest stable

## Why

2026.2 is the latest stable Authentik release. Authentik shifted from a ~2-month to 3-month release cadence; there is no 2026.0 or 2026.1, and 2026.5 is expected in May. The 2025.12 hop (#275) baked successfully so we are clear to make the second jump.

### Breaking-change exposure (full audit in plan)

- `User.ak_groups` deprecated → `User.groups`: not referenced by any blueprint or expression policy
- SCIM `filter_group` → `group_filters` array: we don't use SCIM
- `ak_groups` query param removed from `/rbac/roles/`: no API consumers
- Certificate fingerprint/subject moved to DB; `include_details` query param removed: blueprints `!Find` certs by `name` only
- Recovery link/email endpoints require explicit token-duration param: not used
- Python 3.14 in image: bundled, transparent
- Embedded outpost auto-upgrades with the server pod (only outpost we run)

## Test plan

- [ ] Pre-flight: trigger fresh `cnpg-pg-dump-backup` run and confirm authentik dump exists
- [ ] Pre-flight: confirm no `Configuration warning` events on the live dashboard
- [ ] Pre-flight: snapshot current pod images: `kubectl get pods -n default -l app.kubernetes.io/name=authentik -o jsonpath='{.items[*].spec.containers[*].image}'`
- [ ] CI green
- [ ] After merge: `flux reconcile source helm authentik-charts -n default && flux reconcile helmrelease authentik -n default --with-source`
- [ ] `kubectl rollout status deploy/authentik-server deploy/authentik-worker -n default` succeeds
- [ ] `kubectl logs deploy/authentik-worker -n default --tail=200` shows blueprint apply messages, no `migration inconsistency` errors
- [ ] All `BlueprintInstance` resources are `successful`
- [ ] Login at `https://${OAUTH_URL}` works (OIDC for Grafana — exercises the cert-storage migration via `signing_key: !Find authentik Self-signed Certificate`)
- [ ] Forward-auth gate works for: `ops`, `prometheus`, `alert-manager`, `longhorn`, `weave`, `traefik` dashboard
- [ ] Application tile icons still render in the user library
- [ ] Embedded outpost shows version `2026.2.2` in admin → Outposts
- [ ] No deactivated SCIM providers (we have none, but the upgrade scans for them)
- [ ] No new `Configuration warning` events in admin → Events

## Rollback

Authentik does not support downgrading. If validation fails: `git revert` this commit, then `pg_restore` the most recent pre-upgrade dump from `cnpg-backups-pvc:/backups/authentik/` (procedure in [backup README](../tree/main/infrastructure/backup/README.md) and the upgrade plan).