### PR TITLE
bugfix(auth): fix forward-auth redirect to retired auth2 host

### DIFF
--- a/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
@@ -24,6 +24,31 @@ data:
         identifiers:
           name: authentik Embedded Outpost
         attrs:
+          # config is a single JSONField — DRF replaces it wholesale rather than
+          # deep-merging, so we declare every default key alongside the override.
+          # authentik_host is the URL the outpost redirects browsers to when
+          # starting the auth flow for forward-auth; must track ${OAUTH_URL}.
+          config:
+            authentik_host: https://${OAUTH_URL}
+            authentik_host_browser: https://${OAUTH_URL}
+            authentik_host_insecure: false
+            log_level: info
+            error_reporting_enabled: false
+            object_naming_template: "ak-outpost-%(name)s"
+            container_image: null
+            docker_network: null
+            docker_map_ports: true
+            docker_labels: null
+            kubernetes_replicas: 1
+            kubernetes_namespace: default
+            kubernetes_service_type: ClusterIP
+            kubernetes_disabled_components: []
+            kubernetes_image_pull_secrets: []
+            kubernetes_json_patches: null
+            kubernetes_ingress_class_name: null
+            kubernetes_ingress_secret_name: null
+            kubernetes_ingress_annotations: {}
+            refresh_interval: minutes=5
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, ops-forward-auth]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-forward-auth]]


### PR DESCRIPTION
### Description
- Forward-auth flows for `ops.${SECRET_DOMAIN}`, `alert-manager.${SECRET_DOMAIN}`, and `prometheus.${SECRET_DOMAIN}` now redirect to `https://${OAUTH_URL}` instead of the retired `auth2.${SECRET_DOMAIN}` host. Same fix applies when launching those tiles from authentik's User Library.
- The embedded outpost's `config.authentik_host` (and `authentik_host_browser`) lived in authentik's database with the old auth2 URL — `d79d032` only updated the ingress hostname and Grafana's OAuth URLs, not the outpost record. The blueprint now declares the full outpost config dict, so `${OAUTH_URL}` is enforced on every reconcile.
- Because `config` is a single `JSONField` (DRF replaces it wholesale rather than deep-merging), every `default_outpost_config()` key (`log_level`, `refresh_interval`, `kubernetes_*`, etc.) is declared alongside the override to keep runtime defaults stable.

### Tests and additional notes
No automated test changes — cluster blueprints have no unit-test harness in this repo. Manual verification after merge:
- [ ] Let flux reconcile the `embedded-outpost-blueprint` ConfigMap, then `kubectl rollout restart deploy/authentik-worker -n default` to refresh blueprint discovery (per the blueprint-discovery-stale gotcha).
- [ ] Tail `kubectl logs -n default deploy/authentik-worker | grep -i blueprint` for a clean apply.
- [ ] In a private window, navigate to `ops.${SECRET_DOMAIN}`, `alert-manager.${SECRET_DOMAIN}`, and `prometheus.${SECRET_DOMAIN}` — redirect should land on `${OAUTH_URL}`, not `auth2.${SECRET_DOMAIN}`.
- [ ] Click each Ops / Prometheus / Alertmanager tile in authentik's User Library — same expectation.
- [ ] Confirm the embedded outpost is healthy (Authentik UI → System → Outposts).

---
**Stack**:
- #277 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*