### PR TITLE
feat(auth): synology OIDC SSO with new Apps group

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -38,6 +38,8 @@ spec:
       envFrom:
         - secretRef:
             name: grafana-auth-secrets
+        - secretRef:
+            name: synology-auth-secrets
     authentik:
       email:
         host: smtp.gmail.com
@@ -49,8 +51,10 @@ spec:
         - ops-blueprint
         - prometheus-blueprint
         - alertmanager-blueprint
+        - synology-blueprint
         - embedded-outpost-blueprint
         - ops-group-blueprint
+        - apps-group-blueprint
     server:
       ingress:
         hosts:

--- a/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apps-group-blueprint
+  namespace: default
+data:
+  apps-group.yaml: |
+    version: 1
+    metadata:
+      name: apps-access-group
+    entries:
+      # state: created -> the worker creates this group ONCE and never
+      # reconciles it again. Members added or removed via the authentik UI
+      # thereafter survive every blueprint re-apply. Renaming the group or
+      # flipping is_superuser will require deleting it manually first.
+      # https://docs.goauthentik.io/customize/blueprints/v1/structure/
+      - model: authentik_core.group
+        id: apps-group
+        state: created
+        identifiers:
+          name: Apps
+        attrs:
+          is_superuser: false
+      # PolicyBindings stay state: present (default) so this file is the
+      # authoritative source for "which apps does the Apps group gate?".
+      # Removing a binding requires setting state: absent here, NOT just
+      # deleting the entry — authentik does not prune unmanaged bindings.
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, synology]]
+          group: !KeyOf apps-group
+          order: 0
+        attrs:
+          enabled: true

--- a/apps/prod/authentik/blueprints/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ops
   - prometheus
   - alertmanager
+  - synology
   - embedded-outpost
   - groups

--- a/apps/prod/authentik/blueprints/synology/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/synology/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ops-group.blueprint.yaml
-  - apps-group.blueprint.yaml
+  - synology.blueprint.yaml
+  - synology-auth.sops.yaml

--- a/apps/prod/authentik/blueprints/synology/synology-auth.sops.yaml
+++ b/apps/prod/authentik/blueprints/synology/synology-auth.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: synology-auth-secrets
+    namespace: default
+type: Opaque
+stringData:
+    SYNOLOGY_CLIENT_SECRET: ENC[AES256_GCM,data:NJp15jXSM6pVjCDvCU5qczaHCLiSGbrLaUwDKZY8SBpmfIxWRLT3ifRNqCy7BHXHqA6N5xGHW13MZqd2sLoVwA==,iv:WV0Vlm/tXOu4QvYa5dckUtHZtzFkEpI+uYNCNe3cS0A=,tag:YwaNcA2103r9R1r+/fsSjg==,type:str]
+sops:
+    lastmodified: "2026-05-06T02:44:40Z"
+    mac: ENC[AES256_GCM,data:uG43BJM/YuTSt+aflLNfILd4pKtDBpIBvjXS0b0oUfY9eLc1sfZfGQbU8mWfjl9HNvkxPENz1x0tW6cNqwFxQWB6KYloYxl7tlflbl1i0g3A+Kw7Pf3EatFr2xclaw1drYZcX+4SXa2/Ukm7pRiFPYc7tOf7A5LGCB7izVmlDTs=,iv:gmuB3yEXQBj5ypj6IUR8LIlkne9PEW+IOsfFKNtA11w=,tag:zk4NBFzzUy2CmAkItZZs8A==,type:str]
+    pgp:
+        - created_at: "2026-05-06T02:44:26Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0i7SvTnDueaAQ/+MxyAZE7KHGuT9z0cAdUB7TE5iJKCSgxrojSgvgKQxK4V
+            RXvBUte2uVen+VTlhOS8tvm2K+sina22l+j6itfzAgKCyf1r0AonP1qoVDxoTgjd
+            KjI4QDyzd4MXAtfFkw8kvIdnk8JJIE5Jd95QHQTIAzeo+KBaWwglJslGmK5F4DKY
+            Vl/SA1tL6qicMNbK0cAq5HJ5gkS6uvt+2ufR78FEC5h3Ykuu/oQ8vVCWcU8rpkGT
+            fJnhaZ0pgwTSVaJWkVI2HCqjFXUsNKpCLB4UQCyCWm7F/9xPXQWrRHI22v5aep2x
+            FipQE08x/LXd8ng7H97cSkxlwlA7/Y9F6vjfqBcc9T0wgCX6pAfl90b+c+WDilNt
+            3xwro5We+cff6wG3GFDUwy2GnkVYs3oNaZTLNmgf1Xty11qsSzUritAYiWnK1uwK
+            Lm7BT+Vd7myeEfvyA8mwyAjV/WwoebPvLuDYbaMlf9t4zgsEpoH1FUGP0J3ZNbEu
+            gdQmDPamnWESLphZrCSgqpu744CcmapMOLwrY7qzyrR4VQiV2aj+5hvosiR88UVJ
+            VK7vqJum8SMyXZJKXebpX0EFfbtcF856KhDe34Sw4/7gkJNAquiLsrvufUM4OHTa
+            NBbFsWUekagI8EhYtD4KsTNE/yv/sMf/XLzM32Cu9HQSoHtEi1JJPrd/yKQLffPS
+            XgEL/rQ13z0z00iyBLPjqVjHrihhuMUxHGSVvMXcK1CM877ZPjD3ZJtJAtR4Z1It
+            Kd2WyozodDCWstVBEwhtjGCs7S4Cr3NWmxxpt+F3CNHt6O/Qy+E5o6DlVC0MVYw=
+            =9MO/
+            -----END PGP MESSAGE-----
+          fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/prod/authentik/blueprints/synology/synology.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/synology/synology.blueprint.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synology-blueprint
+  namespace: default
+data:
+  synology.yaml: |
+    version: 1
+    metadata:
+      name: synology-oauth
+    entries:
+      # OAuth2/OIDC provider for Synology DSM 7.2+ SSO Client.
+      # The client_secret is sourced from synology-auth-secrets via the worker
+      # envFrom in authentik.hr.yaml, then read here with !Env.
+      - model: authentik_providers_oauth2.oauth2provider
+        id: synology-provider
+        identifiers:
+          client_id: synology
+        attrs:
+          name: Synology OAuth Provider
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          client_type: confidential
+          client_id: synology
+          client_secret: !Env SYNOLOGY_CLIENT_SECRET
+          # Regex matching covers both the LAN/public hostname and the
+          # variable QuickConnect relay URL. After the first successful sign-in
+          # round-trip, copy the exact URI DSM displays in its SSO Client UI
+          # and tighten this to matching_mode: strict.
+          redirect_uris:
+            - matching_mode: regex
+              url: ^https://nas\.serubin\.me(:\d+)?/.*$
+            - matching_mode: regex
+              url: ^https://[^.]+\.quickconnect\.to/.*$
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "openid"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "email"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "profile"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "groups"]]
+
+      - model: authentik_core.application
+        id: synology-app
+        identifiers:
+          slug: synology
+        attrs:
+          name: Synology
+          slug: synology
+          provider: !KeyOf synology-provider
+          meta_launch_url: https://nas.serubin.me/
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/synology.svg
+          meta_description: Synology NAS (DSM)
+          group: Apps
+          open_in_new_tab: true
+          policy_engine_mode: any


### PR DESCRIPTION
- Synology DSM now authenticates via Authentik OIDC (DSM 7.2+ built-in
SSO Client). Provider, Application, and a SOPS-encrypted client secret
are added.
- New `Apps` access group, sibling to `Ops`. Synology is gated by
`Apps` membership; `Ops` continues to gate ops tooling. Future
user-facing apps land in `Apps`.

---
**Stack**:
- #279 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*