### PR TITLE
bugfix(auth): drop unsupported groups scope from synology provider

### DIFF
--- a/apps/prod/authentik/blueprints/synology/synology.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/synology/synology.blueprint.yaml
@@ -33,11 +33,14 @@ data:
             - matching_mode: regex
               url: ^https://[^.]+\.quickconnect\.to/.*$
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          # The default `profile` scope mapping already emits the `groups`
+          # claim in the userinfo response — there is no separate `groups`
+          # scope mapping shipped with authentik 2026. Adding one would
+          # require a custom ScopeMapping entry; not needed for DSM.
           property_mappings:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "openid"]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "email"]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "profile"]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "groups"]]
 
       - model: authentik_core.application
         id: synology-app


### PR DESCRIPTION
The `groups` scope mapping is not shipped with authentik 2026; only
`openid`, `email`, `profile`, `entitlements`, `offline_access`,
`goauthentik.io/api`, and `ak_proxy` exist. The `!Find` returned None
and broke the synology blueprint, which cascaded to apps-access-group.
The default `profile` scope already emits the groups claim in the
userinfo response, which is what DSM consumes for group-based access
control.

---
**Stack**:
- #280 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*