### PR TITLE
feat(auth): home-outpost forward-auth for media stack + jellyfin OIDC

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -40,6 +40,10 @@ spec:
             name: grafana-auth-secrets
         - secretRef:
             name: synology-auth-secrets
+        - secretRef:
+            name: media-auth-secrets
+        - secretRef:
+            name: jellyfin-auth-secrets
     authentik:
       email:
         host: smtp.gmail.com
@@ -52,9 +56,13 @@ spec:
         - prometheus-blueprint
         - alertmanager-blueprint
         - synology-blueprint
+        - media-blueprint
+        - jellyfin-blueprint
         - embedded-outpost-blueprint
+        - home-outpost-blueprint
         - ops-group-blueprint
         - apps-group-blueprint
+        - media-users-group-blueprint
     server:
       ingress:
         hosts:

--- a/apps/prod/authentik/blueprints/groups/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/groups/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ops-group.blueprint.yaml
   - apps-group.blueprint.yaml
+  - media-users-group.blueprint.yaml

--- a/apps/prod/authentik/blueprints/groups/media-users-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/media-users-group.blueprint.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: media-users-group-blueprint
+  namespace: default
+data:
+  media-users-group.yaml: |
+    version: 1
+    metadata:
+      name: media-users-access-group
+    entries:
+      # state: present (default; Apps/Ops use state: created) so MEDIA_SHARED_PASSWORD
+      # rotations propagate. arr_user/arr_password are read by media-forward-auth's
+      # basic_auth injection.
+      - model: authentik_core.group
+        id: media-users-group
+        identifiers:
+          name: Media Users
+        attrs:
+          is_superuser: false
+          attributes:
+            arr_user: media
+            arr_password: !Env MEDIA_SHARED_PASSWORD
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, media-stack]]
+          group: !KeyOf media-users-group
+          order: 0
+        attrs:
+          enabled: true

--- a/apps/prod/authentik/blueprints/home-outpost/home-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/home-outpost/home-outpost.blueprint.yaml
@@ -1,0 +1,50 @@
+# Single binder for the home-outpost's `providers` list. Same DRF M2M-
+# replacement caveat as embedded-outpost: the outpost's `providers` field is
+# replaced wholesale on each blueprint apply, so only ONE blueprint can manage
+# it without flapping. To bind a new home-located service: define its proxy
+# provider in its own blueprint, then add a `!Find` entry to the list below.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: home-outpost-blueprint
+  namespace: default
+data:
+  home-outpost.yaml: |
+    version: 1
+    metadata:
+      name: home-outpost-bindings
+    entries:
+      - model: authentik_outposts.outpost
+        id: home-outpost
+        identifiers:
+          name: home-outpost
+        attrs:
+          type: proxy
+          # service_connection: null = externally deployed; Authentik will not spawn it.
+          service_connection: null
+          # config is a single JSONField — DRF replaces it wholesale rather than
+          # deep-merging, so we declare every default key alongside the override.
+          # authentik_host must track ${OAUTH_URL}.
+          config:
+            authentik_host: https://${OAUTH_URL}
+            authentik_host_browser: https://${OAUTH_URL}
+            authentik_host_insecure: false
+            log_level: info
+            error_reporting_enabled: false
+            object_naming_template: "ak-outpost-%(name)s"
+            container_image: null
+            docker_network: null
+            docker_map_ports: true
+            docker_labels: null
+            kubernetes_replicas: 1
+            kubernetes_namespace: default
+            kubernetes_service_type: ClusterIP
+            kubernetes_disabled_components: []
+            kubernetes_image_pull_secrets: []
+            kubernetes_json_patches: null
+            kubernetes_ingress_class_name: null
+            kubernetes_ingress_secret_name: null
+            kubernetes_ingress_annotations: {}
+            refresh_interval: minutes=5
+          providers:
+            - !Find [authentik_providers_proxy.proxyprovider, [name, media-forward-auth]]

--- a/apps/prod/authentik/blueprints/home-outpost/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/home-outpost/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - home-outpost.blueprint.yaml

--- a/apps/prod/authentik/blueprints/jellyfin/jellyfin-auth.sops.yaml
+++ b/apps/prod/authentik/blueprints/jellyfin/jellyfin-auth.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: jellyfin-auth-secrets
+    namespace: default
+type: Opaque
+stringData:
+    JELLYFIN_CLIENT_SECRET: ENC[AES256_GCM,data:AfQfmJfHlhqFxY+uQD3v7GBqtqRZhhFD8fsjemfpaqRm5MeVrKcyo231ygd0t6sbse6RP6f2qQriYvgSRicIBw==,iv:ZegB7+oNfXL/ixjrjrLHvbfAUuTUNRg1SiDDdRgXbIU=,tag:elAUgQsAuKkbdKKAHrJxqQ==,type:str]
+sops:
+    lastmodified: "2026-05-09T15:00:48Z"
+    mac: ENC[AES256_GCM,data:hfqjn7UQ5OYZviO5SDretDgazEy25PbA8CR1oyMMRQsThmuqrHvso94hYeck6C1QMh0fdxjRE7SQmidSHkq8BHpG1NtYWJgIhYtbLudmDur20zG3y/MnCSy2PAhwdwtG+BOfkSrstzh8MmXq+3H3PNfgkMG2YUP3cQACFV1cc80=,iv:dLRi6CyBMNtRYqz7pcjbXFLXmh1iDdLwiVGxliktNoA=,tag:daiiq7bCm/5RZ5ULfgxpNQ==,type:str]
+    pgp:
+        - created_at: "2026-05-09T15:00:48Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0i7SvTnDueaAQ//d8mWF0K3KVAgfoyOxwV2pnw4MJTCvwIx+nBt7R7o+6av
+            /IfUHMmTMRmf7bzhfQP5ck1mCo0eeAIGXfMn4CJTotJrVkeMzanYop2ideUDZaB0
+            OIEasMbxlSYukJlOVl106JLZUKe/99kEihvw9K616umqCQindarqJvFA+nTba5yz
+            b0PFgVunuks2UxNSNuwviGiwIBqeKEywPyUU5HkZSa7tJrT8OvtKzqz+wR0T0Mmt
+            /kbnJ+J7yGGrJZ9D2Mo5zDVH5pIAcuy6JvFJ6EHt5dowylVlKCQhOR5y+WAHCt92
+            9rzRxloBXNOfjvhBCkqKwmDMV14YDm3CRhNyIXKe/2yJJyEz+kwV1u/+S+fSPScW
+            xsf7E3bZ7ySU7ZTeEGzxfox99+xteUSMMB9YO6DoC96A/0HsMaz9zkIYGagQYsvR
+            5ZFfXYUUgneEyY81tDdjs3Oml7UUmK0DX2e0Nvjb1fr8n9O7MOprKiY15/S+3Pzz
+            gl9YIfhOn6iyn3GR21g+w8jnzBFTTeLUDGIdeZIGkEGf2SRCkYQxLSjuLqXouw9q
+            9vFQ25pKsrejLpufRWCuGlwaSdORKj6YhgiVgIb8Q5/W/8n9km9th8Cx7egVszNZ
+            hEbudZK6/Cb99x4hj2+WLZpYWONGLi9m75nfIq5/2YYdbiIA+Klks0LGTtxc6onS
+            XgGrLjovtlVnNvIkWFEfePZYBI8oTDcGwn8L7bFyJjtjNzRMi2tHim2/1esbgHdA
+            ievMoUiIocv2riu8X6EAkEVUBQ8eXYFxPHgdP6Ggs3BezAsouQtE5JiwTieJLTY=
+            =ETvt
+            -----END PGP MESSAGE-----
+          fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/prod/authentik/blueprints/jellyfin/jellyfin.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/jellyfin/jellyfin.blueprint.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jellyfin-blueprint
+  namespace: default
+data:
+  jellyfin.yaml: |
+    version: 1
+    metadata:
+      name: jellyfin-oauth
+    entries:
+      # OAuth2/OIDC provider for Jellyfin via the 9p4/jellyfin-plugin-sso plugin.
+      # Strict matching: the plugin's redirect path is exactly
+      # /sso/OID/redirect/<ProviderName> — case-sensitive, single URL.
+      - model: authentik_providers_oauth2.oauth2provider
+        id: jellyfin-provider
+        identifiers:
+          client_id: jellyfin
+        attrs:
+          name: Jellyfin OAuth Provider
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          client_type: confidential
+          client_id: jellyfin
+          client_secret: !Env JELLYFIN_CLIENT_SECRET
+          redirect_uris:
+            - matching_mode: strict
+              url: https://watch.serubin.me/sso/OID/redirect/authentik
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "openid"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "email"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "profile"]]
+
+      - model: authentik_core.application
+        id: jellyfin-app
+        identifiers:
+          slug: jellyfin
+        attrs:
+          name: Jellyfin
+          slug: jellyfin
+          provider: !KeyOf jellyfin-provider
+          meta_launch_url: https://watch.serubin.me/sso/OID/start/authentik
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/jellyfin.svg
+          meta_description: Jellyfin media server
+          group: Apps
+          open_in_new_tab: true
+          policy_engine_mode: any

--- a/apps/prod/authentik/blueprints/jellyfin/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/jellyfin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - jellyfin.blueprint.yaml
+  - jellyfin-auth.sops.yaml

--- a/apps/prod/authentik/blueprints/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kustomization.yaml
@@ -6,5 +6,8 @@ resources:
   - prometheus
   - alertmanager
   - synology
+  - media
+  - jellyfin
   - embedded-outpost
+  - home-outpost
   - groups

--- a/apps/prod/authentik/blueprints/media/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/media/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - media.blueprint.yaml
+  - media-auth.sops.yaml

--- a/apps/prod/authentik/blueprints/media/media-auth.sops.yaml
+++ b/apps/prod/authentik/blueprints/media/media-auth.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: media-auth-secrets
+    namespace: default
+type: Opaque
+stringData:
+    MEDIA_SHARED_PASSWORD: ENC[AES256_GCM,data:anSarkHAScuiJCkMX9iDrRgrD1VEGFEodTUIlqQlMp6CPL11BYGsXACyruxOLHW1Z+YVXWRnIO57OG90llUemA==,iv:SRniibojBu3GlySXLkEyb65m4DK3ixQ0kgEjEJezcok=,tag:aTaA6W5ZsJKby4WkBUCC5A==,type:str]
+sops:
+    lastmodified: "2026-05-09T15:00:31Z"
+    mac: ENC[AES256_GCM,data:EHYchEFpVWFVsJ8DedPtxE967llsE3eIlhqkbwEl1Q1oKNdH8u14OXfcPtAzA0zE6PIx27n+vOYO4jhhl0II1onFkJxHXEd3QsUH/cU8ZOXw4WMUw+kMLNjZQTkCbsYaOnTYOW1z0n1UacATOkYsA4vGD6o0qdgcGYnUCbPNyuY=,iv:l1FfY1qJv2TES4sQ5xRm61hmIC/aKsHQHzfoX0hAcIo=,tag:IQXIGWnQL2VdT8aa10qYug==,type:str]
+    pgp:
+        - created_at: "2026-05-09T15:00:31Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0i7SvTnDueaAQ//bPGpZ/IKZIzZytKjXC4VHdjXbwxS0GEGh+5RImo8qBlF
+            DAJyezfextbOu+UGAP7WYSbLHQQ3yoC2icMvaT+YZX9wDmu5tCbLlIMqI1sRFkPq
+            p5S1q6sudGAIJDRz6JlVnKdkvDalb6tYaPa0dhfabmqBQQY5K32YAcG+hzLHmu2U
+            Fy3zuxIIOUNDzrKy7vI6PMLp97cp3uYjR/dLGH0PVAj0LkoLEgDdkCTcX0I4fDvi
+            9bsYMRB5d3UxVFtGg26RPT6GXfiH9RPrqrfogIO7S8UdIDpYE7isj3fW/8FE3NdI
+            OfH4d2y86lzYFoZ44Cmp6+xrcqwO1Mn7083oPy3R5sOlixpB7wliX7Yzsn1VLtHO
+            pDHKNfn1L28wiO0y3s7u/e2BonRXgozMH6pfYxIowaR52VkxsFZyqpXwxzxdHdmd
+            EwukEymlh4UtRdQAppvghcHy3Y3JXEWwNtmubnGJY/QNAUjFSWdY1tpvNPBSCiYO
+            v6ahF9yiazDh+djNOVEtsOEPU11R79Q3IRIK2JPZ+7o9YZnomyRD89u2gVum4xDI
+            BQDGYWZv/5U9gbhsc/4hYUrz6Ydc++TmbVCYP/gQwEodvZnjiL0OaBQiGRuayqtb
+            C+y+zAEaxwl/zHd0QhbZNFDtD1cm3Uz+Kt+OJ93mXWm+BiBrjW8wZq+32limPW7S
+            XAEf0nEbPR8MLd9v/ZIu2swC8Vztg6kHLwaEQKvopViWtBopieGcEQzA5aQEM9Ux
+            v/4vr9ytJYCZR72SYzcVqL6qsUmExbZNp+wZLW2EtLc488b9C3kqn50RAnIV
+            =23J+
+            -----END PGP MESSAGE-----
+          fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/prod/authentik/blueprints/media/media.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/media/media.blueprint.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: media-blueprint
+  namespace: default
+data:
+  media.yaml: |
+    version: 1
+    metadata:
+      name: media-forward-auth
+    entries:
+      - model: authentik_providers_proxy.proxyprovider
+        id: media-provider
+        identifiers:
+          name: media-forward-auth
+        attrs:
+          name: Media Forward Auth Provider
+          external_host: https://serubin.me
+          # internal_host is unused in forward_single mode but required by the serializer.
+          internal_host: http://localhost
+          internal_host_ssl_validation: false
+          mode: forward_single
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          basic_auth_enabled: true
+          basic_auth_user_attribute: arr_user
+          basic_auth_password_attribute: arr_password
+
+      - model: authentik_core.application
+        id: media-stack-app
+        identifiers:
+          slug: media-stack
+        attrs:
+          name: Media Stack
+          slug: media-stack
+          provider: !KeyOf media-provider
+          # blank://blank hides the tile from the user library while keeping
+          # the forward-auth proxy provider for serubin.me active.
+          meta_launch_url: blank://blank
+          meta_description: Auth gate for serubin.me (Sonarr, Radarr, Prowlarr, Bazarr)
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any
+
+      # Tile-only Applications: deep-link launchers in the user library; protection comes from the host-level forward-auth above.
+      - model: authentik_core.application
+        id: sonarr-app
+        identifiers:
+          slug: sonarr
+        attrs:
+          name: Sonarr
+          slug: sonarr
+          meta_launch_url: https://serubin.me/sonarr
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/sonarr.svg
+          meta_description: TV series management
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any
+
+      - model: authentik_core.application
+        id: radarr-app
+        identifiers:
+          slug: radarr
+        attrs:
+          name: Radarr
+          slug: radarr
+          meta_launch_url: https://serubin.me/radarr
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/radarr.svg
+          meta_description: Movie management
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any
+
+      - model: authentik_core.application
+        id: prowlarr-app
+        identifiers:
+          slug: prowlarr
+        attrs:
+          name: Prowlarr
+          slug: prowlarr
+          meta_launch_url: https://serubin.me/prowlarr
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prowlarr.svg
+          meta_description: Indexer management
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any
+
+      - model: authentik_core.application
+        id: bazarr-app
+        identifiers:
+          slug: bazarr
+        attrs:
+          name: Bazarr
+          slug: bazarr
+          meta_launch_url: https://serubin.me/bazarr
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bazarr.svg
+          meta_description: Subtitle management
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any


### PR DESCRIPTION
### Description

- Authentik now gates the media stack and Jellyfin.
- Media stack runs behind a new forward-auth proxy provider with HTTP Basic Auth credential injection, bound to a new dedicated `home-outpost` for NAS-resident services. Embedded outpost untouched.
- Jellyfin gets an OIDC provider for the third-party SSO-Auth plugin.
- New SOPS secrets wired into the worker `envFrom`; new `Media Users` group carries the shared credential attrs.
- NAS-side rollout (home-outpost container, Traefik labels, plugin install) follows separately.

---
**Stack**:
- #281 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*