### PR TITLE
feat(alerts): wire up email receiver for alertmanager

### DIFF
--- a/apps/base/prometheus/alertmanager.sops.yaml
+++ b/apps/base/prometheus/alertmanager.sops.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: alertmanager-secrets
+    namespace: default
+stringData:
+    TO_EMAIL: ENC[AES256_GCM,data:VbFOq8r9sSkLdIZWRgJUprBQ,iv:XZZsAUVGhiRdKSUyK3b6jpQqNMFdr2PQXMrZNb3AqVU=,tag:h+/ru+1V9EDIJ0jktQ+rqQ==,type:str]
+sops:
+    lastmodified: "2026-05-10T01:48:45Z"
+    mac: ENC[AES256_GCM,data:47bqn0/+R1paRhW/ZJA/Yk3+ixO3mX9YV8JHhr990zaWfrBzUPjmvdti9rFSRPJOD1+nOdqoeYBxtD5tAcpODh8hgZAXdtmYryYK4GTh+wX4RneDrBlHvVexnpshFQlCLZKzIBObEaLEnDIGhHFme6/6MiOaLS4vTHmUOAAPT/g=,iv:aDkpbPsJxibIS4ZbVpjqmGWYGaMJIlb6YIV3wSozQ1M=,tag:hzMyPSWpotiT+bGy1rvf3Q==,type:str]
+    pgp:
+        - created_at: "2026-05-10T01:48:45Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0i7SvTnDueaAQ//d4efcQuphDcmCzroSOUvO5mPirulZQ5uADAaiLoeR7J4
+            yefrYfADjQl8dMSnGQ2WrbOatRKWeoFiVrtuCKxKgN/M0l6bj9+jTPNXI07J7to7
+            OlHPmj/Si9SddBNs8vz3Q1wugLwkKJedu61zjP65+CrL5U9hzGkWw4vJ0W5opjG+
+            LiH0TsnPz/8975ILVzgA8LUtT6n+uqga+VFPhhdtqqLjXZVIPEKuJtWTf8f5OKx9
+            YyrICxIuV9i0XIJwOsxoRw69D8R5z9ATiTUww9GQwd3X1s2kd4wtsVYfKGTNBNfU
+            0bML1e03I++xOFvpZUAIeCgldmkgb2faBj2fDP/IfHSVpU6vRP/N/qnk79LJ3vke
+            OOVZ7eF4neUOSxdcxtPA1FV9kmD//CiO2/q4PohLO3XR6/Bj09CbxIgxu7SOVOSq
+            Ieklp2SmhSU6WV45R6LJ++pqqaXUzzsnHeEE7PRnfisdNy4csq9DvpYJy+vkpfpL
+            EzN/b8OLRf6t1slw1TwaTuqc7W94/KDCNXBT/cDh/p2CLv/mZyXb7BXmew+399/e
+            gz+hcfMh5Ql4/amtFvLUemOyt/Ql+JL5XzBshSWf+vg2vmkYVwrD1+DsPOzHLs0E
+            fZaaIeDYNcYAGkezuoYVDk2zvWohGy40MMnlFGVYo8us9k/+8tPWEdblB4wC3SjS
+            XgHcdsJY3XIipH7+wxb1I3ExXX6L9EcbXTaPEPYyoeoGwAm53lUcO7AaV3G6BzIB
+            UswdHq1DgVoP+/NHjaKscI+BY143tlyfR+ZTfxEBMyfCQsdEzSkz6eKxdRDME1Y=
+            =A7GN
+            -----END PGP MESSAGE-----
+          fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/base/prometheus/kustomization.yaml
+++ b/apps/base/prometheus/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: default
 resources:
   - prometheus.sops.yaml
+  - alertmanager.sops.yaml
   - prometheus.hr.yaml

--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -25,6 +25,26 @@ spec:
       valuesKey: GRAFANA_CLIENT_SECRET
       targetPath: grafana.env.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
       optional: false
+    - kind: Secret
+      name: cluster-secrets
+      valuesKey: NOREPLY_SEND_EMAIL
+      targetPath: alertmanager.config.global.smtp_from
+      optional: false
+    - kind: Secret
+      name: cluster-secrets
+      valuesKey: NOREPLY_AUTH_EMAIL
+      targetPath: alertmanager.config.global.smtp_auth_username
+      optional: false
+    - kind: Secret
+      name: cluster-secrets
+      valuesKey: NOREPLY_PASSWORD
+      targetPath: alertmanager.config.global.smtp_auth_password
+      optional: false
+    - kind: Secret
+      name: alertmanager-secrets
+      valuesKey: TO_EMAIL
+      targetPath: alertmanager.config.receivers[0].email_configs[0].to
+      optional: false
   values:
     alertmanager:
       image:
@@ -32,6 +52,32 @@ spec:
       ingress:
         hosts:
           - "alert-manager.${SECRET_DOMAIN}"
+      config:
+        global:
+          resolve_timeout: 5m
+          smtp_smarthost: "smtp.gmail.com:587"
+          smtp_require_tls: true
+        route:
+          group_by: ["alertname", "namespace"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 4h
+          receiver: email-default
+        receivers:
+          - name: email-default
+            email_configs:
+              - send_resolved: true
+        inhibit_rules:
+          - source_matchers: [severity = "critical"]
+            target_matchers: [severity =~ "warning|info"]
+            equal: [namespace, alertname]
+          - source_matchers: [severity = "warning"]
+            target_matchers: [severity = "info"]
+            equal: [namespace, alertname]
+          - source_matchers: [alertname = "InfoInhibitor"]
+            target_matchers: [severity = "info"]
+            equal: [namespace]
+          - target_matchers: [alertname = "InfoInhibitor"]
     grafana:
       image:
         tag: 12.3.1


### PR DESCRIPTION
### Description

- Alerts that fire in Prometheus now actually deliver instead of being swallowed by the chart's default null receiver. A single `email-default` receiver routes all alerts to a per-cluster destination over Gmail SMTP (`smtp.gmail.com:587`, STARTTLS, `smtp_require_tls: true`).
- SMTP credentials (`from`, `username`, `password`) are injected via `valuesFrom` against `cluster-secrets` (`NOREPLY_SEND_EMAIL` / `NOREPLY_AUTH_EMAIL` / `NOREPLY_PASSWORD`). The destination address (`TO_EMAIL`) lives in a new SOPS-encrypted Secret `alertmanager-secrets`, added at `apps/base/prometheus/alertmanager.sops.yaml` and wired through the base kustomization.
- `Watchdog` (severity=none, fires continuously) keeps routing through the catch-all and delivers as a heartbeat — one email at AM startup, then one every `repeat_interval` (4h). If Watchdog stops mailing, AM/Prom is broken.
- Inhibit rules from the chart defaults are copied into the inline config (critical suppresses warning/info on the same `namespace`+`alertname`; `InfoInhibitor` suppresses info on the same namespace). Required because overriding `alertmanager.config` replaces the chart's block wholesale — no deep merge.

---
**Stack**:
- #284 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*