### PR TITLE
bugfix(alerts): use ${NOREPLY_*} substitution for SMTP creds

### DIFF
--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -26,21 +26,6 @@ spec:
       targetPath: grafana.env.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
       optional: false
     - kind: Secret
-      name: cluster-secrets
-      valuesKey: NOREPLY_SEND_EMAIL
-      targetPath: alertmanager.config.global.smtp_from
-      optional: false
-    - kind: Secret
-      name: cluster-secrets
-      valuesKey: NOREPLY_AUTH_EMAIL
-      targetPath: alertmanager.config.global.smtp_auth_username
-      optional: false
-    - kind: Secret
-      name: cluster-secrets
-      valuesKey: NOREPLY_PASSWORD
-      targetPath: alertmanager.config.global.smtp_auth_password
-      optional: false
-    - kind: Secret
       name: alertmanager-secrets
       valuesKey: TO_EMAIL
       targetPath: alertmanager.config.receivers[0].email_configs[0].to
@@ -57,6 +42,9 @@ spec:
           resolve_timeout: 5m
           smtp_smarthost: "smtp.gmail.com:587"
           smtp_require_tls: true
+          smtp_from: "${NOREPLY_SEND_EMAIL}"
+          smtp_auth_username: "${NOREPLY_AUTH_EMAIL}"
+          smtp_auth_password: "${NOREPLY_PASSWORD}"
         route:
           group_by: ["alertname", "namespace"]
           group_wait: 30s


### PR DESCRIPTION
### Description

- Fixes prometheus HR failing to reconcile with `secrets "cluster-secrets" not found`. helm-controller's `valuesFrom` only resolves Secrets in the HR's own namespace (`default`), but `cluster-secrets` lives in `flux-system`.
- Replaces the three `cluster-secrets` `valuesFrom` entries with inline `${NOREPLY_SEND_EMAIL}` / `${NOREPLY_AUTH_EMAIL}` / `${NOREPLY_PASSWORD}` placeholders in `alertmanager.config.global`. Substitution is already wired via `prod-apps` Kustomization's `postBuild.substituteFrom: cluster-secrets` — same mechanism `${SECRET_DOMAIN}` and `${OAUTH_URL}` use elsewhere in this file.
- `alertmanager-secrets` / `TO_EMAIL` `valuesFrom` is unchanged (that Secret lives in `default`).

---
**Stack**:
- #285 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*