### PR TITLE
bugfix(alerts): clear chart default Watchdog->null child route

### DIFF
--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -51,6 +51,7 @@ spec:
           group_interval: 5m
           repeat_interval: 4h
           receiver: email-default
+          routes: []
         receivers:
           - name: email-default
             email_configs:


### PR DESCRIPTION
### Description

- Fixes prometheus-operator failing to provision the alertmanager Secret with `undefined receiver "null" used in route`. The kube-prometheus-stack chart's default `alertmanager.config.route` includes a child route `routes: [{receiver: 'null', matchers: [alertname="Watchdog"]}]`. Helm deep-merges our `route` over the chart's, so when we don't set `routes`, the chart's child route survives. Our `receivers` list (a list, replaced wholesale) only declares `email-default`, leaving the surviving child route pointing at an undefined receiver.
- Sets `route.routes: []` to clear chart-supplied child routes. Watchdog now falls through to the catch-all `email-default` receiver, matching the user-chosen behavior of keeping Watchdog as a continuous email heartbeat.
- HR was reporting `Helm upgrade succeeded`, but the operator was rejecting the resulting Secret, so the running alertmanager pod kept serving the previous (chart-default) config — no SMTP delivery despite a "successful" upgrade.

---
**Stack**:
- #286 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*