### PR TITLE
feat(alerts): include severity in alertmanager email subject

### DIFF
--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -56,6 +56,8 @@ spec:
           - name: email-default
             email_configs:
               - send_resolved: true
+                headers:
+                  Subject: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}][{{ .CommonLabels.severity | toUpper }}] {{ .GroupLabels.alertname }}'
         inhibit_rules:
           - source_matchers: [severity = "critical"]
             target_matchers: [severity =~ "warning|info"]


### PR DESCRIPTION
### Description

- Email subjects now lead with status and severity, e.g. `[FIRING:1][CRITICAL] HighMemoryUsage` and `[RESOLVED][WARNING] DiskPressure`. Lets recipients triage from the inbox without opening the message.
- Adds `email_configs[0].headers.Subject` template to the `email-default` receiver: `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}][{{ .CommonLabels.severity | toUpper }}] {{ .GroupLabels.alertname }}`. Uses `.CommonLabels.severity` (only populated when all alerts in the group share severity), so a mixed-severity group renders an empty bracket — acceptable since `route.group_by` is `[alertname, namespace]` and severity rarely splits within a single alertname.