### PR TITLE
feat(observability): add loki + alloy log aggregation

### DIFF
--- a/apps/base/loki/alloy.hr.yaml
+++ b/apps/base/loki/alloy.hr.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: default
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: alloy
+      version: 1.8.1
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: default
+      interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    crds:
+      create: false
+    controller:
+      type: daemonset
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+    alloy:
+      mounts:
+        varlog: true
+      configMap:
+        create: true
+        content: |
+          logging {
+            level  = "info"
+            format = "logfmt"
+          }
+
+          discovery.kubernetes "pods" {
+            role = "pod"
+          }
+
+          discovery.relabel "pod_logs" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+              target_label  = "app"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+              separator     = "/"
+              target_label  = "__path__"
+              replacement   = "/var/log/pods/*$1/*.log"
+            }
+            rule {
+              action        = "replace"
+              source_labels = ["__meta_kubernetes_pod_container_id"]
+              regex         = "^(\\w+):\\/\\/.+$"
+              replacement   = "$1"
+              target_label  = "tmp_container_runtime"
+            }
+          }
+
+          loki.source.kubernetes "pods" {
+            targets    = discovery.relabel.pod_logs.output
+            forward_to = [loki.process.pod_logs.receiver]
+          }
+
+          loki.process "pod_logs" {
+            stage.match {
+              selector = "{tmp_container_runtime=\"containerd\"} |~ \"^[^ ]+ stderr|stdout [^ ]\""
+
+              stage.regex {
+                expression = "^(?P<timestamp>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
+              }
+              stage.labels {
+                values = {
+                  stream = "stream",
+                }
+              }
+              stage.output {
+                source = "content"
+              }
+            }
+
+            stage.label_drop {
+              values = ["tmp_container_runtime"]
+            }
+
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki.default.svc.cluster.local:3100/loki/api/v1/push"
+            }
+          }

--- a/apps/base/loki/kustomization.yaml
+++ b/apps/base/loki/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - loki.hr.yaml
+  - alloy.hr.yaml
+  - loki-datasource.cm.yaml

--- a/apps/base/loki/loki-datasource.cm.yaml
+++ b/apps/base/loki/loki-datasource.cm.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-grafana-datasource
+  namespace: default
+  labels:
+    grafana_datasource: "1"
+data:
+  loki-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.default.svc.cluster.local:3100
+        isDefault: false
+        jsonData:
+          maxLines: 1000

--- a/apps/base/loki/loki.hr.yaml
+++ b/apps/base/loki/loki.hr.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: default
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: loki
+      version: 6.55.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: default
+      interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+        path_prefix: /var/loki
+      storage:
+        type: filesystem
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      limits_config:
+        retention_period: 168h
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+        max_cache_freshness_per_query: 10m
+        split_queries_by_interval: 15m
+        query_timeout: 300s
+        volume_enabled: true
+        allow_structured_metadata: true
+      compactor:
+        retention_enabled: true
+        delete_request_store: filesystem
+        compaction_interval: 10m
+        retention_delete_delay: 2h
+        retention_delete_worker_count: 150
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: longhorn
+        size: 20Gi
+        accessModes:
+          - ReadWriteOnce
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    minio:
+      enabled: false
+    gateway:
+      enabled: false
+    test:
+      enabled: false
+    lokiCanary:
+      enabled: false
+    monitoring:
+      selfMonitoring:
+        enabled: false
+        grafanaAgent:
+          installOperator: false
+      serviceMonitor:
+        enabled: true
+        metricsInstance:
+          enabled: false
+      dashboards:
+        enabled: false
+      rules:
+        enabled: false

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - kutt
   - lacework
   - lemonhope
+  - loki
   - nocodb
   - plausible
   - serubin-net

--- a/apps/prod/loki/kustomization.yaml
+++ b/apps/prod/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/loki

--- a/charts/grafana.chart.yaml
+++ b/charts/grafana.chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: grafana-charts
+  namespace: default
+spec:
+  interval: 30m
+  url: https://grafana.github.io/helm-charts
+  timeout: 2m

--- a/charts/kustomization.yaml
+++ b/charts/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - christianhuth.chart.yaml
   - cloudnativepg.chart.yaml
   - cloudpirates.chart.yaml
+  - grafana.chart.yaml
   - kyverno.chart.yaml
   - lacework.chart.yaml
   - longhorn.chart.yaml


### PR DESCRIPTION
### Description
Adds a Loki single-binary log store backed by a 20Gi Longhorn PVC (7-day
retention) and a Grafana Alloy DaemonSet that tails every pod's stdout/stderr
across all namespaces and pushes to Loki. A `grafana_datasource: "1"`
ConfigMap auto-registers Loki as a Grafana datasource via the existing
sidecar — so logs are queryable from Grafana's Explore tab, gated by the
existing Authentik OIDC. Loki itself has no Ingress; only Grafana and
Alloy reach it in-cluster. Adds a `grafana-charts` HelmRepository.

---
**Stack**:
- #288 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*