### PR TITLE
feat(capacitor): install gimlet capacitor flux UI

### DIFF
--- a/apps/base/capacitor/capacitor.ingressroute.yaml
+++ b/apps/base/capacitor/capacitor.ingressroute.yaml
@@ -1,0 +1,113 @@
+---
+# IPWhiteList: only allow traffic from the WireGuard tunnel client range.
+# The CIDR is held in cluster-secrets (VPN_TUNNEL_CIDR) and substituted by
+# Flux postBuild so the network topology stays out of git. Traefik runs as a
+# hostPort DaemonSet with no proxyProtocol/trustedIPs configured, so the
+# connection source IP is the actual client; default ipStrategy reads that
+# connection IP (not X-Forwarded-For), which is what we want here.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: capacitor-vpn-only
+  namespace: flux-system
+spec:
+  ipWhiteList:
+    sourceRange:
+      - ${VPN_TUNNEL_CIDR}
+---
+# Local copy of forwardauth-authentik. Cross-namespace middleware refs are off
+# (no allowCrossNamespace=true on the Traefik DaemonSet), so any IngressRoute
+# in flux-system needs this middleware in the same namespace. Mirrors the
+# longhorn-system copy at infrastructure/longhorn/longhorn.ingress.yaml.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: forwardauth-authentik
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: authentik
+spec:
+  forwardAuth:
+    address: http://authentik-server.default.svc.cluster.local:80/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-entitlements
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid
+      - X-authentik-jwt
+      - X-authentik-meta-jwks
+      - X-authentik-meta-outpost
+      - X-authentik-meta-provider
+      - X-authentik-meta-app
+      - X-authentik-meta-version
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: capacitor-stripprefix
+  namespace: flux-system
+spec:
+  stripPrefix:
+    prefixes:
+      - /capacitor
+---
+# Normalize /capacitor -> /capacitor/ so stripPrefix doesn't strip the request
+# down to an empty path (which capacitor's SPA serves as a 404). Mirrors the
+# longhorn-redirect-slash pattern.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: capacitor-redirect-slash
+  namespace: flux-system
+spec:
+  redirectRegex:
+    regex: ^(https?://[^/]+)/capacitor$
+    replacement: ${1}/capacitor/
+    permanent: true
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: capacitor
+  namespace: flux-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`ops.${SECRET_DOMAIN}`) && PathPrefix(`/capacitor`)
+      kind: Rule
+      services:
+        - name: capacitor
+          port: 9000
+      middlewares:
+        - name: capacitor-vpn-only
+        - name: forwardauth-authentik
+        - name: capacitor-redirect-slash
+        - name: capacitor-stripprefix
+---
+# Capacitor's Vite build hardcodes base: '/' (web/vite.config.mjs), so the SPA
+# emits absolute URLs to /assets/*, /api/*, and /health from the browser. We
+# reserve those root paths on ops.${SECRET_DOMAIN} for the capacitor backend
+# (no stripPrefix). Forward-auth still applies — the session cookie is
+# host-scoped, so XHRs from the loaded SPA carry it.
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: capacitor-rootpaths
+  namespace: flux-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`ops.${SECRET_DOMAIN}`) && (PathPrefix(`/assets`) || PathPrefix(`/api`) || Path(`/health`))
+      kind: Rule
+      services:
+        - name: capacitor
+          port: 9000
+      middlewares:
+        - name: capacitor-vpn-only
+        - name: forwardauth-authentik

--- a/apps/base/capacitor/capacitor.rbac.yaml
+++ b/apps/base/capacitor/capacitor.rbac.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capacitor
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capacitor
+rules:
+  - apiGroups:
+      - networking.k8s.io
+      - apps
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - ingresses
+      - deployments
+      - services
+      - secrets
+      - events
+      - configmaps
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - infra.contrib.fluxcd.io
+    resources:
+      - gitrepositories
+      - ocirepositories
+      - buckets
+      - helmrepositories
+      - helmcharts
+      - kustomizations
+      - helmreleases
+      - terraforms
+    verbs:
+      - get
+      - watch
+      - list
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capacitor
+subjects:
+  - kind: ServiceAccount
+    name: capacitor
+    namespace: flux-system
+roleRef:
+  kind: ClusterRole
+  name: capacitor
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/base/capacitor/capacitor.yaml
+++ b/apps/base/capacitor/capacitor.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: capacitor
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/name: capacitor
+    app.kubernetes.io/instance: capacitor
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: capacitor
+    app.kubernetes.io/instance: capacitor
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capacitor
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/name: capacitor
+    app.kubernetes.io/instance: capacitor
+  annotations:
+    kubectl.kubernetes.io/default-container: capacitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: capacitor
+      app.kubernetes.io/instance: capacitor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: capacitor
+        app.kubernetes.io/instance: capacitor
+    spec:
+      serviceAccountName: capacitor
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: capacitor
+          image: ghcr.io/gimlet-io/capacitor:v0.4.8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/base/capacitor/kustomization.yaml
+++ b/apps/base/capacitor/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - capacitor.rbac.yaml
+  - capacitor.yaml
+  - capacitor.ingressroute.yaml

--- a/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/ops/ops.blueprint.yaml
@@ -77,3 +77,16 @@ data:
           open_in_new_tab: true
           group: Ops
           policy_engine_mode: any
+      - model: authentik_core.application
+        id: capacitor-app
+        identifiers:
+          slug: capacitor
+        attrs:
+          name: Capacitor
+          slug: capacitor
+          meta_launch_url: https://ops.${SECRET_DOMAIN}/capacitor
+          icon: https://raw.githubusercontent.com/gimlet-io/capacitor/main/web/public/favicon.ico
+          meta_description: Flux GitOps Dashboard
+          open_in_new_tab: true
+          group: Ops
+          policy_engine_mode: any

--- a/apps/prod/capacitor/kustomization.yaml
+++ b/apps/prod/capacitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/capacitor

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - prometheus
   - authentik
   - aj4democracy
+  - capacitor
   - dysautonomia-web
   - jpat-web
   - kutt

--- a/configs/prod/cluster-secrets.sops.yaml
+++ b/configs/prod/cluster-secrets.sops.yaml
@@ -35,9 +35,11 @@ stringData:
     #ENC[AES256_GCM,data:yq4/B1EN1Q==,iv:2mKgZCuf5hyMxAbhPAjfNJkeCwXZFNfu6S9isDqqRpY=,tag:PshyVamu8qfsOG2A0fyJZw==,type:comment]
     VELERO_B2_BUCKET: ENC[AES256_GCM,data:ZlZ9VAM6//OYPPKFE+ftK9cvsjChvMVDcQ==,iv:o4spyrlhkyPYrzlrK2zCDcpT5oH6NSbMc9oBQopt2cQ=,tag:LNZIfnh0ny5X6oBuxhTsYg==,type:str]
     VELERO_B2_ENDPOINT: ENC[AES256_GCM,data:WPEXjA4pA1RkOdF+d/t0gAvrTW25qFK0pIfXhmQlCV1rJj8PmuQ=,iv:NXfeHRQCS53CDk/EVYzLsO+F/cYB8lp2FoSJCIb3kg8=,tag:A3Yigzc6QNsVGzc//NRt1Q==,type:str]
+    #ENC[AES256_GCM,data:GZMz4Q==,iv:nq8ELlX0FePQEd7lSkyfR8fYWv0YLANGxJ4PUCsy5pw=,tag:vXKR2SgBjBEYAR8DmxCqzQ==,type:comment]
+    VPN_TUNNEL_CIDR: ENC[AES256_GCM,data:/bWthzcxh7En0cE=,iv:Mj60i5Xla1W/Ne2wLswyxGvl20HOrNCktKR8MbgqPq0=,tag:6zgl56JhDfW6voeozFulWg==,type:str]
 sops:
-    lastmodified: "2026-05-04T02:45:57Z"
-    mac: ENC[AES256_GCM,data:8dWxjGs9DKKxgnYqp/IzHte8a1rI+IpCthRI8GXFijrcU+0YQHOqqLFyI1gqShFYsv007o3OhiCL82Mc2sMSWYZoFqxoLdcgR89dTTOkw9qaE/7OcPyrOhBOpkAXjDUlp7acfFxoqtejsq9+7v+/csKMWvIX+umDjktogDTZnyw=,iv:AseEkMayvRarx6GxWqoHx0GnqUYY5U/v5g9LLa38IWc=,tag:ox7UqdKuqjEFscoZ9XxjiA==,type:str]
+    lastmodified: "2026-05-10T15:16:58Z"
+    mac: ENC[AES256_GCM,data:Nt/G5oyVyGUWoc/qrbSTez2fepYfeaWO8Vgzbx40cqAaPEqWQFovQgJcvU0TqxnS1RtBxowqpCo2ym/LorZyAMI2H3IvjTXNm4st81hmMkvi1GnvLoFq5nRs9CRXhDI7NV/rJuzMhtv1FCkvPr89Gj0oiumdPYS+04zEXEjEeto=,iv:/1rVRQwwuBVBBkgWXQlXW5an5AiIJetXjLTcDKl/3B4=,tag:COX6+riw+9iB61xkCw3daw==,type:str]
     pgp:
         - created_at: "2025-12-10T00:36:44Z"
           enc: |-


### PR DESCRIPTION
### Description
Adds the Capacitor (gimlet-io v0.4.8) Flux dashboard at `https://ops.${SECRET_DOMAIN}/capacitor`, gated by Authentik forward-auth and a Traefik IPWhiteList scoped to the WireGuard tunnel range so it's reachable only over the split-tunnel VPN.

- New `apps/base/capacitor/` deploys capacitor in `flux-system` (read-only ClusterRole on Flux + core resources, plus `patch` for force-reconcile).
- Two Traefik IngressRoutes on `ops.`: `/capacitor` with stripPrefix for the SPA, and a catch-all on `/api`/`/assets`/`/health` for the root-relative URLs the Vite build emits (capacitor v0.4.x hardcodes `base: '/'`).
- Local copies of `forwardauth-authentik` and a new `capacitor-vpn-only` middleware in `flux-system` (cross-namespace middleware refs are off cluster-wide).
- VPN allowlist CIDR is held in `cluster-secrets` as `VPN_TUNNEL_CIDR` and injected via Flux postBuild substitution so network topology stays out of git.
- Adds a `capacitor` tile to the Ops blueprint; needs `kubectl rollout restart deploy/authentik-worker -n default` post-merge so discovery picks it up.

---
**Stack**:
- #289 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*