### PR TITLE
chore(observability): map grafana admin role to Ops group

### DIFF
--- a/apps/prod/prometheus/prometheus.hr.yaml
+++ b/apps/prod/prometheus/prometheus.hr.yaml
@@ -84,8 +84,8 @@ spec:
         GF_AUTH_SIGNOUT_REDIRECT_URL: "https://${OAUTH_URL}/application/o/grafana/end-session/"
         # Optionally enable auto-login (bypasses Grafana login screen)
         GF_AUTH_OAUTH_AUTO_LOGIN: "true"
-        # Optionally map user groups to Grafana roles
-        GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'Grafana Admins') && 'Admin' || contains(groups[*], 'Grafana Editors') && 'Editor' || 'Viewer'"
+        # Map user groups to Grafana roles
+        GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'Ops') && 'Admin' || 'Viewer'"
       ingress:
         hosts:
           - "grafana.${SECRET_DOMAIN}"


### PR DESCRIPTION
### Description
Grafana role mapping previously keyed on `Grafana Admins` / `Grafana Editors`
groups that don't exist in any Authentik blueprint, so every SSO user fell
through to `Viewer`. Switches the role attribute path to grant `Admin` to
members of the existing `Ops` group (the same group that gates Grafana
access in the first place) and `Viewer` to everyone else. Users must
re-login for the new role to take effect.

---
**Stack**:
- #290 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*