### PR TITLE
bugfix(capacitor): move out of flux-system namespace

### DIFF
--- a/apps/base/capacitor/capacitor.ingressroute.yaml
+++ b/apps/base/capacitor/capacitor.ingressroute.yaml
@@ -9,7 +9,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: capacitor-vpn-only
-  namespace: flux-system
+  namespace: capacitor
 spec:
   ipWhiteList:
     sourceRange:
@@ -17,13 +17,13 @@ spec:
 ---
 # Local copy of forwardauth-authentik. Cross-namespace middleware refs are off
 # (no allowCrossNamespace=true on the Traefik DaemonSet), so any IngressRoute
-# in flux-system needs this middleware in the same namespace. Mirrors the
-# longhorn-system copy at infrastructure/longhorn/longhorn.ingress.yaml.
+# in this namespace needs this middleware here too. Mirrors the longhorn-system
+# copy at infrastructure/longhorn/longhorn.ingress.yaml.
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: forwardauth-authentik
-  namespace: flux-system
+  namespace: capacitor
   labels:
     app.kubernetes.io/instance: authentik
     app.kubernetes.io/name: authentik
@@ -49,7 +49,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: capacitor-stripprefix
-  namespace: flux-system
+  namespace: capacitor
 spec:
   stripPrefix:
     prefixes:
@@ -62,7 +62,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: capacitor-redirect-slash
-  namespace: flux-system
+  namespace: capacitor
 spec:
   redirectRegex:
     regex: ^(https?://[^/]+)/capacitor$
@@ -73,7 +73,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: capacitor
-  namespace: flux-system
+  namespace: capacitor
 spec:
   entryPoints:
     - websecure
@@ -98,7 +98,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: capacitor-rootpaths
-  namespace: flux-system
+  namespace: capacitor
 spec:
   entryPoints:
     - websecure

--- a/apps/base/capacitor/capacitor.namespace.yaml
+++ b/apps/base/capacitor/capacitor.namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capacitor
+  labels:
+    app.kubernetes.io/name: capacitor

--- a/apps/base/capacitor/capacitor.rbac.yaml
+++ b/apps/base/capacitor/capacitor.rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: capacitor
-  namespace: flux-system
+  namespace: capacitor
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -53,7 +53,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: capacitor
-    namespace: flux-system
+    namespace: capacitor
 roleRef:
   kind: ClusterRole
   name: capacitor

--- a/apps/base/capacitor/capacitor.yaml
+++ b/apps/base/capacitor/capacitor.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: capacitor
-  namespace: flux-system
+  namespace: capacitor
   labels:
     app.kubernetes.io/name: capacitor
     app.kubernetes.io/instance: capacitor
@@ -21,7 +21,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capacitor
-  namespace: flux-system
+  namespace: capacitor
   labels:
     app.kubernetes.io/name: capacitor
     app.kubernetes.io/instance: capacitor

--- a/apps/base/capacitor/kustomization.yaml
+++ b/apps/base/capacitor/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
+namespace: capacitor
 resources:
+  - capacitor.namespace.yaml
   - capacitor.rbac.yaml
   - capacitor.yaml
   - capacitor.ingressroute.yaml


### PR DESCRIPTION
### Description
Capacitor was deployed in `flux-system`, where the bootstrap-managed `allow-egress` NetworkPolicy selects all pods and only permits ingress from other flux-system pods. Traefik (in `kube-system`) was being denied at the CNI, surfacing as 502 Bad Gateway with `connection refused` on the pod IP even though capacitor itself was listening.

Move capacitor to a dedicated `capacitor` namespace so Flux's isolation policies don't apply. RBAC is cluster-scoped, so the namespace is otherwise arbitrary.

---
**Stack**:
- #291 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*