### PR TITLE
feat(kutt): route serub.in/s/ to kutt

### DIFF
--- a/apps/prod/kutt/kustomization.yaml
+++ b/apps/prod/kutt/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/kutt
   - kutt.sops.yaml
+  - kutt.ingressroute.yaml
 patches:
   - path: postgres.hr.yaml
     target:

--- a/apps/prod/kutt/kutt.ingressroute.yaml
+++ b/apps/prod/kutt/kutt.ingressroute.yaml
@@ -1,0 +1,24 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: kutt-stripprefix
+  namespace: default
+spec:
+  stripPrefix:
+    prefixes:
+      - /s
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kutt-shortlinks
+  namespace: default
+spec:
+  routes:
+    - match: Host(`serub.in`) && PathPrefix(`/s`)
+      kind: Rule
+      services:
+        - name: kutt
+          port: 80
+      middlewares:
+        - name: kutt-stripprefix


### PR DESCRIPTION
### Description
Adds a Traefik `IngressRoute` + `stripPrefix` middleware so `https://serub.in/s/<slug>` resolves to the same Kutt-managed short links served on `s-r.io` and `seru.us`. The catch-all `serub.in/` route still goes to `serubin-net`; the more-specific `/s` prefix wins for `/s/*`.

Note: upstream Kutt has no `BASE_PATH` support, so the Kutt UI continues to generate links on the existing first ingress host (`s-r.io`); `serub.in/s/<slug>` works as a manually-shared alias.

---
**Stack**:
- #292 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*