### PR TITLE
feat(kutt): add OIDC sign-in via authentik

### DIFF
--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -42,6 +42,8 @@ spec:
             name: synology-auth-secrets
         - secretRef:
             name: jellyfin-auth-secrets
+        - secretRef:
+            name: kutt-auth-secrets
     authentik:
       email:
         host: smtp.gmail.com
@@ -56,6 +58,7 @@ spec:
         - synology-blueprint
         - media-blueprint
         - jellyfin-blueprint
+        - kutt-blueprint
         - embedded-outpost-blueprint
         - home-outpost-blueprint
         - ops-group-blueprint

--- a/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
@@ -32,3 +32,10 @@ data:
           order: 0
         attrs:
           enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, kutt]]
+          group: !KeyOf apps-group
+          order: 1
+        attrs:
+          enabled: true

--- a/apps/prod/authentik/blueprints/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - synology
   - media
   - jellyfin
+  - kutt
   - embedded-outpost
   - home-outpost
   - groups

--- a/apps/prod/authentik/blueprints/kutt/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kutt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kutt.blueprint.yaml
+  - kutt-auth.sops.yaml

--- a/apps/prod/authentik/blueprints/kutt/kutt-auth.sops.yaml
+++ b/apps/prod/authentik/blueprints/kutt/kutt-auth.sops.yaml
@@ -1,0 +1,12 @@
+# PLACEHOLDER — encrypt before committing.
+#   1. Replace REPLACE_ME with the OIDC client secret (`openssl rand -base64 48`).
+#   2. Run: sops --encrypt --in-place apps/prod/authentik/blueprints/kutt/kutt-auth.sops.yaml
+#   3. Verify the resulting file has ENC[...] for the stringData value.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kutt-auth-secrets
+  namespace: default
+type: Opaque
+stringData:
+  KUTT_CLIENT_SECRET: REPLACE_ME

--- a/apps/prod/authentik/blueprints/kutt/kutt.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/kutt/kutt.blueprint.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kutt-blueprint
+  namespace: default
+data:
+  kutt.yaml: |
+    version: 1
+    metadata:
+      name: kutt-oauth
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: kutt-provider
+        identifiers:
+          client_id: kutt
+        attrs:
+          name: Kutt OAuth Provider
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          client_type: confidential
+          client_id: kutt
+          client_secret: !Env KUTT_CLIENT_SECRET
+          redirect_uris:
+            - matching_mode: strict
+              url: https://s-r.io/login/oidc
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "openid"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "email"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "profile"]]
+
+      - model: authentik_core.application
+        id: kutt-app
+        identifiers:
+          slug: kutt
+        attrs:
+          name: Kutt
+          slug: kutt
+          provider: !KeyOf kutt-provider
+          meta_launch_url: https://s-r.io
+          icon: https://raw.githubusercontent.com/thedevs-network/kutt/develop/static/images/logo.svg
+          meta_description: URL shortener
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any

--- a/apps/prod/kutt/kutt.hr.yaml
+++ b/apps/prod/kutt/kutt.hr.yaml
@@ -20,7 +20,19 @@ spec:
       valuesKey: NOREPLY_PASSWORD
       targetPath: kutt.mail.password
       optional: false
+    # OIDC client secret is injected into the extraEnv list at the index of the
+    # OIDC_CLIENT_SECRET entry below. Reordering the list breaks this binding.
+    - kind: Secret
+      name: kutt-auth-secrets
+      valuesKey: KUTT_CLIENT_SECRET
+      targetPath: extraEnv[3].value
+      optional: false
   values:
+    # Pinned to the kutt/kutt:main image digest because v3.2.3 has no OIDC
+    # (merged in PR #880, unreleased). Bumping requires re-resolving the digest
+    # of the upstream :main tag.
+    image:
+      tag: "main@sha256:ddd7257bc8c57f4892d2a81ec0d7d25ea0167b60d1dd7112868630644402956f"
     ingress:
       hosts:
         - host: s-r.io
@@ -32,14 +44,28 @@ spec:
             - path: /
               pathType: Prefix
     kutt:
-      google:
-        existingSecret: kutt-secrets
       recaptcha:
         existingSecret: kutt-secrets
       jwt:
         existingSecret: kutt-secrets
       mail:
         reportEmail: "${ADMIN_EMAIL}"
+    # Order matters: extraEnv[3] is bound by `valuesFrom` above.
+    extraEnv:
+      - name: OIDC_ENABLED
+        value: "true"
+      - name: OIDC_ISSUER
+        value: "https://${OAUTH_URL}/application/o/kutt/"
+      - name: OIDC_CLIENT_ID
+        value: "kutt"
+      - name: OIDC_CLIENT_SECRET
+        value: "placeholder-overridden-by-valuesFrom"
+      - name: OIDC_SCOPE
+        value: "openid email profile"
+      - name: OIDC_EMAIL_CLAIM
+        value: "email"
+      - name: DISALLOW_LOGIN_FORM
+        value: "true"
     postgresql:
       enabled: false
     externalPostgresql:


### PR DESCRIPTION
### Description
- Pin image to `kutt/kutt:main@sha256:ddd7257b…` — v3.2.3 has no OIDC (PR thedevs-network/kutt#880 unreleased).
- Register OAuth2 provider + Application in Authentik (Apps-group gated); redirect URI for `s-r.io`.
- Inject OIDC env via the chart's `extraEnv`; client secret bound through `valuesFrom` → `extraEnv[3].value`.
- Drop dead `kutt.google.existingSecret`; set `DISALLOW_LOGIN_FORM=true` so OIDC is the canonical sign-in.
- `kutt-auth.sops.yaml` is committed unencrypted (placeholder `REPLACE_ME`) — sops-encrypt before merging to main.

---
**Stack**:
- #295 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*