### PR TITLE
fix(renovate): broaden manager file patterns to match multi-dot basenames

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,10 @@
   ],
   "flux": {
     "managerFilePatterns": [
-      "/^[^\\.]*\\.ya?ml$/"
+      "infrastructure/**/*.yaml",
+      "apps/**/*.yaml",
+      "charts/**/*.yaml",
+      "clusters/**/*.yaml"
     ]
   },
   "helm-values": {
@@ -25,14 +28,17 @@
   },
   "kubernetes": {
     "managerFilePatterns": [
-      "/^apps/[^\\.]*\\.ya?ml$/"
+      "apps/**/*.yaml"
     ]
   },
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^[^\\.]*\\.ya?ml$/"
+        "infrastructure/**/*.yaml",
+        "apps/**/*.yaml",
+        "charts/**/*.yaml",
+        "clusters/**/*.yaml"
       ],
       "matchStrings": [
         "datasource=(?<datasource>\\S+) depName=(?<depName>.*?)\n *version: (?<currentValue>.*)\n"


### PR DESCRIPTION
Renovate's flux, kubernetes, and customManagers regex
(^[^\.]*\.ya?ml$) required no dots before the .yaml suffix, which
silently excluded every *.hr.yaml, *.chart.yaml, *.ingress.yaml and
similar file in the repo. Result: chart/HelmRelease version updates
have not been opening PRs (Longhorn, cloudnativepg, kyverno, velero,
loki, grafana, kutt, redis, authentik, vaultwarden, weave, etc.).

Switch the three buggy patterns to globs that cover the actual repo
layout. helm-values already used .* and is left alone.

Expect a backlog of Renovate PRs on the next run.

---
**Stack**:
- #299
- #298 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*