### PR TITLE
chore(cnpg): exclude broken logical replication alerts from cluster 0.6.0

### DIFF
--- a/apps/base/authentik/postgres.hr.yaml
+++ b/apps/base/authentik/postgres.hr.yaml
@@ -25,6 +25,14 @@ spec:
         enabled: true
         podMonitor:
           enabled: true
+        prometheusRule:
+          # cluster chart 0.6.0 ships two rules whose PromQL applies a range
+          # selector to an aggregated instant vector (invalid syntax), causing
+          # the prometheus-operator admission webhook to reject the whole rule
+          # group. Remove once upstream fixes the expressions.
+          excludeRules:
+            - CNPGClusterLogicalReplicationErrors
+            - CNPGClusterLogicalReplicationErrorsCritical
       initdb:
         database: authentik
         owner: authentik

--- a/apps/base/kutt/postgres.hr.yaml
+++ b/apps/base/kutt/postgres.hr.yaml
@@ -25,6 +25,14 @@ spec:
         enabled: true
         podMonitor:
           enabled: true
+        prometheusRule:
+          # cluster chart 0.6.0 ships two rules whose PromQL applies a range
+          # selector to an aggregated instant vector (invalid syntax), causing
+          # the prometheus-operator admission webhook to reject the whole rule
+          # group. Remove once upstream fixes the expressions.
+          excludeRules:
+            - CNPGClusterLogicalReplicationErrors
+            - CNPGClusterLogicalReplicationErrorsCritical
       initdb:
         database: kutt
         owner: kutt

--- a/apps/base/nocodb/postgres.hr.yaml
+++ b/apps/base/nocodb/postgres.hr.yaml
@@ -25,6 +25,14 @@ spec:
         enabled: true
         podMonitor:
           enabled: true
+        prometheusRule:
+          # cluster chart 0.6.0 ships two rules whose PromQL applies a range
+          # selector to an aggregated instant vector (invalid syntax), causing
+          # the prometheus-operator admission webhook to reject the whole rule
+          # group. Remove once upstream fixes the expressions.
+          excludeRules:
+            - CNPGClusterLogicalReplicationErrors
+            - CNPGClusterLogicalReplicationErrorsCritical
       initdb:
         database: nocodb
         owner: nocodb

--- a/apps/base/plausible/postgres.hr.yaml
+++ b/apps/base/plausible/postgres.hr.yaml
@@ -25,6 +25,14 @@ spec:
         enabled: true
         podMonitor:
           enabled: true
+        prometheusRule:
+          # cluster chart 0.6.0 ships two rules whose PromQL applies a range
+          # selector to an aggregated instant vector (invalid syntax), causing
+          # the prometheus-operator admission webhook to reject the whole rule
+          # group. Remove once upstream fixes the expressions.
+          excludeRules:
+            - CNPGClusterLogicalReplicationErrors
+            - CNPGClusterLogicalReplicationErrorsCritical
       initdb:
         database: plausible
         owner: plausible


### PR DESCRIPTION
### Description
`cluster` chart 0.6.0 ships `CNPGClusterLogicalReplicationErrors{,Critical}` with invalid PromQL (`[5m]` applied to an aggregated instant vector), which the prometheus-operator admission webhook rejects. Every CNPG-backed `HelmRelease` (authentik, kutt, nocodb, plausible) was failing `helm upgrade` as a result, blocking dependent HRs from reconciling.

Adds `prometheusRule.excludeRules` for those two alerts to the four base postgres HRs. All other CNPG alerts remain. Revert once upstream fixes the expressions.

---
**Stack**:
- #334 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*