### PR TITLE
chore(charts): bump HelmRepository to source.toolkit.fluxcd.io/v1

### DIFF
--- a/charts/authentik.chart.yaml
+++ b/charts/authentik.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: authentik-charts

--- a/charts/bjw-s.chart.yaml
+++ b/charts/bjw-s.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bjw-s-charts

--- a/charts/christianhuth.chart.yaml
+++ b/charts/christianhuth.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: christianhuth-helm-chart

--- a/charts/cloudnativepg.chart.yaml
+++ b/charts/cloudnativepg.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudnativepg-charts

--- a/charts/cloudpirates.chart.yaml
+++ b/charts/cloudpirates.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudpirates-charts

--- a/charts/grafana.chart.yaml
+++ b/charts/grafana.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-charts

--- a/charts/kyverno.chart.yaml
+++ b/charts/kyverno.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kyverno-charts

--- a/charts/lacework.chart.yaml
+++ b/charts/lacework.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: lacework-charts

--- a/charts/longhorn.chart.yaml
+++ b/charts/longhorn.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: longhorn-charts

--- a/charts/pascaliske.chart.yaml
+++ b/charts/pascaliske.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: pascaliske-charts

--- a/charts/prometheus.chart.yaml
+++ b/charts/prometheus.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-charts

--- a/charts/vaultwarden.chart.yaml
+++ b/charts/vaultwarden.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: vaultwarden-charts

--- a/charts/velero.chart.yaml
+++ b/charts/velero.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: velero-charts

--- a/charts/weave.chart.yaml
+++ b/charts/weave.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: weave-gitops-charts

--- a/charts/zekker6.chart.yaml
+++ b/charts/zekker6.chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: zekker6-charts


### PR DESCRIPTION
### Description
Flux 2.8.x dropped support for `source.toolkit.fluxcd.io/v1beta2`; the `HelmRepository` CRD now only serves `v1`, which was failing the `prod-charts` Kustomization with `no matches for kind "HelmRepository" in version "source.toolkit.fluxcd.io/v1beta2"`.

Bumps all 15 `charts/*.chart.yaml` files to the GA `v1` API. The fields in use (`url`, `interval`, `timeout`, optional `type: oci`) are unchanged between versions — pure version-string swap.

---
**Stack**:
- #335 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*