### PR TITLE
chore(cnpg): also exclude broken LogicalReplicationStopped alerts

### DIFF
--- a/apps/base/authentik/postgres.hr.yaml
+++ b/apps/base/authentik/postgres.hr.yaml
@@ -33,6 +33,8 @@ spec:
           excludeRules:
             - CNPGClusterLogicalReplicationErrors
             - CNPGClusterLogicalReplicationErrorsCritical
+            - CNPGClusterLogicalReplicationStopped
+            - CNPGClusterLogicalReplicationStoppedCritical
       initdb:
         database: authentik
         owner: authentik

--- a/apps/base/kutt/postgres.hr.yaml
+++ b/apps/base/kutt/postgres.hr.yaml
@@ -33,6 +33,8 @@ spec:
           excludeRules:
             - CNPGClusterLogicalReplicationErrors
             - CNPGClusterLogicalReplicationErrorsCritical
+            - CNPGClusterLogicalReplicationStopped
+            - CNPGClusterLogicalReplicationStoppedCritical
       initdb:
         database: kutt
         owner: kutt

--- a/apps/base/nocodb/postgres.hr.yaml
+++ b/apps/base/nocodb/postgres.hr.yaml
@@ -33,6 +33,8 @@ spec:
           excludeRules:
             - CNPGClusterLogicalReplicationErrors
             - CNPGClusterLogicalReplicationErrorsCritical
+            - CNPGClusterLogicalReplicationStopped
+            - CNPGClusterLogicalReplicationStoppedCritical
       initdb:
         database: nocodb
         owner: nocodb

--- a/apps/base/plausible/postgres.hr.yaml
+++ b/apps/base/plausible/postgres.hr.yaml
@@ -33,6 +33,8 @@ spec:
           excludeRules:
             - CNPGClusterLogicalReplicationErrors
             - CNPGClusterLogicalReplicationErrorsCritical
+            - CNPGClusterLogicalReplicationStopped
+            - CNPGClusterLogicalReplicationStoppedCritical
       initdb:
         database: plausible
         owner: plausible


### PR DESCRIPTION
### Description
Follow-up to #334. Server-side dry-run revealed two more broken alerts shipped by `cluster` chart 0.6.0 that the prometheus-operator admission webhook rejects:

- `CNPGClusterLogicalReplicationStopped`
- `CNPGClusterLogicalReplicationStoppedCritical`

Both compare an instant vector to a string literal (`label_replace(...) == ""`), which Prometheus parses as `binary expression must contain only scalar and instant vector types`. Adding them to `excludeRules` on the four postgres HRs. With all four exclusions in place, `kubectl apply --dry-run=server` of the rendered PrometheusRule succeeds.

---
**Stack**:
- #336 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*