### PR TITLE
bugfix(vaultwarden): adapt yubico.secretKey to chart 0.36.4 schema

### DIFF
--- a/apps/prod/vaultwarden/vaultwarden.hr.yaml
+++ b/apps/prod/vaultwarden/vaultwarden.hr.yaml
@@ -1,7 +1,7 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: vaultwarden-hr
+  name: vaultwarden
   namespace: default
 spec:
   valuesFrom:
@@ -33,6 +33,7 @@ spec:
       existingSecretKey: adminToken
     yubico:
       clientId: ${YUBICO_CLIENT_ID}
-      secretKey: ${YUBICO_SECRET_KEY}
+      secretKey:
+        value: ${YUBICO_SECRET_KEY}
     smtp:
       fromName: "Bitwarden @ Serubin.net"

--- a/apps/staging/vaultwarden/vaultwarden.hr.yaml
+++ b/apps/staging/vaultwarden/vaultwarden.hr.yaml
@@ -1,7 +1,7 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: vaultwarden-hr
+  name: vaultwarden
   namespace: default
 spec:
   valuesFrom:
@@ -31,6 +31,7 @@ spec:
       existingSecretKey: adminToken
     yubico:
       clientId: ${YUBICO_CLIENT_ID}
-      secretKey: ${YUBICO_SECRET_KEY}
+      secretKey:
+        value: ${YUBICO_SECRET_KEY}
     smtp:
       fromName: "Bitwarden @ Serubin.net"


### PR DESCRIPTION
### Description
Chart 0.36.4 expects `yubico.secretKey` as an object (`{value, existingSecretKey}`), not a raw string. Helm upgrade was failing at template time with `can't evaluate field value in type interface {}`. Wraps the substituted value as `yubico.secretKey.value` in the prod and staging overlays.

Also fixes the overlay file's metadata: `apiVersion: helm.toolkit.fluxcd.io/v2` and `metadata.name: vaultwarden` (was `networking.k8s.io/v1` / `vaultwarden-hr`) so the kustomize patch targets the base HR cleanly by kind+name instead of relying on a typo-tolerant kind-only match.

---
**Stack**:
- #337 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*