### PR TITLE
bugfix(plausible): set clickhouse service controller for app-template v3

### DIFF
--- a/apps/base/plausible/clickhouse.hr.yaml
+++ b/apps/base/plausible/clickhouse.hr.yaml
@@ -48,6 +48,7 @@ spec:
                   periodSeconds: 5
     service:
       main:
+        controller: main
         ports:
           http:
             port: 8123


### PR DESCRIPTION
### Description
app-template v3 (#317) made `service.<name>.controller` a required field; without it, schema validation fails with `at '/service/main': missing property 'controller'` and the helm upgrade aborts. Wires `service.main.controller: main` in the base clickhouse HR. PVC `plausible-clickhouse-pvc` is referenced via `existingClaim`, so data is untouched.

---
**Stack**:
- #339
- #338 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*