### PR TITLE
bugfix(vaultwarden): bind existing PVC under storage.* for chart 0.36.4

### DIFF
--- a/apps/base/plausible/clickhouse.hr.yaml
+++ b/apps/base/plausible/clickhouse.hr.yaml
@@ -48,6 +48,7 @@ spec:
                   periodSeconds: 5
     service:
       main:
+        controller: main
         ports:
           http:
             port: 8123

--- a/apps/base/vaultwarden/vaultwarden.hr.yaml
+++ b/apps/base/vaultwarden/vaultwarden.hr.yaml
@@ -22,11 +22,14 @@ spec:
     ingress:
       enabled: true
       class: ""
-    data:
-      name: "vaultwarden-data"
-      size: "5Gi"
-      class: "longhorn"
-      keepPvc: true
+    storage:
+      # Chart 0.36.4 moved persistence under `storage.*`. The original chart-
+      # managed PVC has `helm.sh/resource-policy: keep`, so it survived the
+      # upgrade — reuse it via existingVolumeClaim rather than letting the
+      # chart create a fresh empty PVC.
+      existingVolumeClaim:
+        claimName: vaultwarden-data-vaultwarden-0
+        dataPath: /data
     smtp:
       enabled: true
       host: "smtp.gmail.com"


### PR DESCRIPTION
### Description
Chart 0.36.4 moved persistence from the top-level `data:` block to `storage.*` and added `storage.existingVolumeClaim` for adopting an out-of-chart PVC. The base HR still used the old `data:` key, which the new chart silently ignored — so the upgraded Deployment rendered with no volume, mounted nothing at `/data`, and started against an empty in-container filesystem. Users could no longer log in: vault data was untouched on the original longhorn PVC, but the pod wasn't connected to it.

Wires the new pod back to the original `vaultwarden-data-vaultwarden-0` PVC via `storage.existingVolumeClaim`. The PVC carries `helm.sh/resource-policy: keep`, so the chart upgrade left it intact for adoption. After this lands, the chart will no longer manage the PVC's lifecycle — keep that in mind for any future PVC resize/storageClass change.

---
**Stack**:
- #339 ⬅
- #338
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*