### PR TITLE
bugfix(prometheus): persist alertmanager silences via longhorn PVC

### DIFF
--- a/apps/base/prometheus/prometheus.hr.yaml
+++ b/apps/base/prometheus/prometheus.hr.yaml
@@ -48,6 +48,14 @@ spec:
       config:
         global:
           resolve_timeout: 5m
+      alertmanagerSpec:
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn
+              resources:
+                requests:
+                  storage: 1Gi
     grafana:
       enabled: true
       image:


### PR DESCRIPTION
### Description

Alertmanager silences disappeared on every kube-prometheus-stack update. Root cause: Alertmanager had **no persistent volume** — unlike the Prometheus block right below it, the `alertmanager` block had no `alertmanagerSpec.storage`. Silences are written to a `silences` file under Alertmanager's data dir (`--storage.path`, default `/alertmanager`), which was backed by an `emptyDir` and wiped whenever the pod was recreated (i.e. every helm upgrade).

This adds an `alertmanagerSpec.storage.volumeClaimTemplate` (1Gi, `longhorn`) mirroring the existing Prometheus `storageSpec`, in `base/` so it applies wherever the stack is deployed.

**One-time rollout caveat:** a StatefulSet's `volumeClaimTemplates` is immutable, so the Prometheus operator will delete and recreate the Alertmanager StatefulSet on this rollout. Silences existing at that moment are lost one final time; everything after persists. If the operator doesn't auto-recreate: `kubectl delete statefulset -n default alertmanager-kube-prometheus-stack-alertmanager`.