### PR TITLE
bugfix(velero): roll back plugin to v1.14.0 to fix B2 backups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,13 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "velero/velero-plugin-for-aws"
+      ],
+      "allowedVersions": "<=1.14.0",
+      "description": "Pinned: v1.14.1's aws-sdk-go-v2 sends an x-amz-tagging header that Backblaze B2 rejects (HTTP 400), breaking all Velero backups. Raise this cap once upstream releases the conditional-Tagging fix (commit 8dbd6b8)."
+    },
+    {
+      "matchPackageNames": [
         "ghcr.io/serubin/serubin-net",
         "ghcr.io/serubin/dysautonomia-lounge-website",
         "ghcr.io/j-paterson/personalwebsite",

--- a/infrastructure/velero/velero.hr.yaml
+++ b/infrastructure/velero/velero.hr.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: velero
-      version: 12.0.2
+      version: 12.0.1
       sourceRef:
         kind: HelmRepository
         name: velero-charts
@@ -24,7 +24,12 @@ spec:
   values:
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.14.1
+        # Pinned to v1.14.0: v1.14.1's aws-sdk-go-v2 emits an x-amz-tagging header
+        # that Backblaze B2 rejects (HTTP 400 InvalidArgument), failing every backup
+        # at the velero-backup.json upload. Renovate is capped at <=1.14.0
+        # (.github/renovate.json) until upstream releases the conditional-Tagging
+        # fix (velero-plugin-for-aws commit 8dbd6b8).
+        image: velero/velero-plugin-for-aws:v1.14.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target


### PR DESCRIPTION
### Description

All Velero backups to Backblaze B2 have been **Failed** since ~2026-05-31. They back up every item, then die at the final `velero-backup.json` upload:

```
PutObject ... 400 InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call
```

**Root cause:** PR #345 (2026-05-27) bumped `velero-plugin-for-aws` v1.14.0 → v1.14.1. v1.14.1's only changes were a Go 1.25.9 / Velero 1.18.1 bump, which pulled a newer `aws-sdk-go-v2` that serializes an (empty) `x-amz-tagging` header on every `PutObject`. Backblaze B2 rejects that header outright. The plugin sets the `Tagging` field unconditionally; the guard that skips it when no tags are configured (commit `8dbd6b8`) is on `main` but unreleased — so there is no config-level escape hatch on v1.14.x. Last `Completed` backup was 2026-05-24, on v1.14.0.

**Fix:** revert to the last known-good released state.

- `velero-plugin-for-aws` v1.14.1 → **v1.14.0**
- velero chart 12.0.2 → **12.0.1** (velero server 1.18.1 → 1.18.0)

v1.14.0 is the exact build that produced the last successful backup, needs no `checksumAlgorithm` workaround, and v1.14.x is the supported pairing for velero v1.18.x. Renovate is capped at `<=1.14.0` so the broken bump isn't re-applied; raise the cap once upstream releases `8dbd6b8`.

After merge + Flux reconcile, verify a schedule-triggered backup reaches `Completed`.

Note: this does **not** address the separate `KubeJobFailed` alert for the 3 corrupt Kopia repo-maintenance jobs (`kube-system`/`kyverno`/`longhorn-system`), which is a truncated-index-blob issue to be repaired separately.