### PR TITLE
Add app.kubernetes.io/name label to base app deployments

### DIFF
--- a/apps/base/aj4democracy/aj4democracy.yaml
+++ b/apps/base/aj4democracy/aj4democracy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: aj4democracy
+    app.kubernetes.io/name: ajd-site
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: aj4democracy
+        app.kubernetes.io/name: ajd-site
     spec:
       containers:
         - name: aj4democracy

--- a/apps/base/dysautonomia-web/dysautonomia-web.yaml
+++ b/apps/base/dysautonomia-web/dysautonomia-web.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: dysautonomia-web
+    app.kubernetes.io/name: dysautonomia-web
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: dysautonomia-web
+        app.kubernetes.io/name: dysautonomia-web
     spec:
       containers:
         - name: dysautonomia-web

--- a/apps/base/jpat-web/jpat-web.yaml
+++ b/apps/base/jpat-web/jpat-web.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: jpat-web
+    app.kubernetes.io/name: jpat-web
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: jpat-web
+        app.kubernetes.io/name: jpat-web
     spec:
       containers:
         - name: jpat-web

--- a/apps/base/lemonhope/lemonhope.yaml
+++ b/apps/base/lemonhope/lemonhope.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: lemonhope
+    app.kubernetes.io/name: lemonhope
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: lemonhope
+        app.kubernetes.io/name: lemonhope
     spec:
       containers:
         - name: lemonhope

--- a/apps/base/loki/alloy.hr.yaml
+++ b/apps/base/loki/alloy.hr.yaml
@@ -104,6 +104,24 @@ spec:
               }
             }
 
+            // ajd-site emits structured JSON logs; promote `level` to a label
+            // so it can be filtered without a query-time `| json`. Scoped by
+            // selector so the JSON parser only runs on this app's lines.
+            stage.match {
+              selector = "{app=\"ajd-site\"}"
+
+              stage.json {
+                expressions = {
+                  level = "level",
+                }
+              }
+              stage.labels {
+                values = {
+                  level = "level",
+                }
+              }
+            }
+
             stage.label_drop {
               values = ["tmp_container_runtime"]
             }

--- a/apps/base/serubin-net/serubin-net.yaml
+++ b/apps/base/serubin-net/serubin-net.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: serubin-net
+    app.kubernetes.io/name: serubin-net
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: serubin-net
+        app.kubernetes.io/name: serubin-net
     spec:
       containers:
         - name: serubin-net

--- a/apps/base/whoami/whoami.yaml
+++ b/apps/base/whoami/whoami.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     app: whoami
+    app.kubernetes.io/name: whoami
 
 spec:
   replicas: 1
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: whoami
+        app.kubernetes.io/name: whoami
       annotations:
         backup.velero.io/backup-volumes-excludes: data
     spec:


### PR DESCRIPTION
Adds the standard app.kubernetes.io/name label to the Deployment
metadata and pod template labels for aj4democracy, dysautonomia-web,
jpat-web, lemonhope, serubin-net, and whoami. This gives each workload a
stable identity label without altering the existing immutable `app`
selector.

---
**Stack**:
- #394
- #393 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*