### PR TITLE
Promote log level to a Loki label for ajd-site in Alloy

### DIFF
--- a/apps/base/loki/alloy.hr.yaml
+++ b/apps/base/loki/alloy.hr.yaml
@@ -104,6 +104,24 @@ spec:
               }
             }
 
+            // ajd-site emits structured JSON logs; promote `level` to a label
+            // so it can be filtered without a query-time `| json`. Scoped by
+            // selector so the JSON parser only runs on this app's lines.
+            stage.match {
+              selector = "{app=\"ajd-site\"}"
+
+              stage.json {
+                expressions = {
+                  level = "level",
+                }
+              }
+              stage.labels {
+                values = {
+                  level = "level",
+                }
+              }
+            }
+
             stage.label_drop {
               values = ["tmp_container_runtime"]
             }


### PR DESCRIPTION
Adds an Alloy pipeline stage that parses ajd-site's structured JSON logs
and promotes `level` to a Loki label so it can be filtered without a
query-time `| json`. Scoped by selector so the JSON parser only runs on
this app's lines.

---
**Stack**:
- #394 ⬅
- #393
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*