### PR TITLE
bugfix(vaultwarden): drop prod additionalHostnames to fix chart 0.43.0 reconcile

### DIFF
--- a/apps/prod/vaultwarden/vaultwarden.hr.yaml
+++ b/apps/prod/vaultwarden/vaultwarden.hr.yaml
@@ -26,8 +26,6 @@ spec:
     ingress:
       enabled: true
       hostname: vault.${SECRET_DOMAIN}
-      additionalHostnames:
-        - bitwarden.${SECRET_DOMAIN}
     adminToken:
       existingSecret: vaultwarden-secrets
       existingSecretKey: adminToken


### PR DESCRIPTION
### Description
Prod vaultwarden was failing to reconcile: the `0.38.0 → 0.43.0` Helm upgrade errored during render (`ingress.yaml:67: can't evaluate field Values in type interface {}`), leaving the release stuck on `0.38.0`. The chart's `ingress.yaml` (bug introduced in `0.42.0`, still on upstream `main`) references `.Values.rocket.tls.secretName` instead of `$.Values...` inside the `additionalHostnames` range, so `.` is the hostname string rather than the root context. The branch only executes when `additionalHostnames` is non-empty — which is why prod broke and staging did not.

- Removes the `additionalHostnames` (`bitwarden.${SECRET_DOMAIN}`) entry from the prod HelmRelease so the buggy code path no longer runs, letting `0.43.0` render and the upgrade proceed.
- Effect: vaultwarden ingress now serves only `vault.${SECRET_DOMAIN}`; the `bitwarden.${SECRET_DOMAIN}` alias is no longer routed.

---
**Stack**:
- #396 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*