### PR TITLE
feat(aj4democracy): enable verification bypass

### DIFF
--- a/apps/prod/aj4democracy/aj4democracy.sops.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.sops.yaml
@@ -20,6 +20,8 @@ stringData:
     features__whatsapp_link: ENC[AES256_GCM,data:jKWoTmwUH/S/8DQwlizdwtEbLv1nMxwBNvwlN/Tlh5qI95S1iUW9wtwTdyUkZh5Mlg==,iv:GmCuR61Ner0xC7kgBNml5Gzy6j/dSqbMoOSurmt+/ww=,tag:L3ufo6GZxA1rTDSaqtoNqw==,type:str]
     features__email_enabled: ENC[AES256_GCM,data:WM2zOA==,iv:UCJfwTbbXt+Pvw3AoBRy6PNiIQuHtQ4KFrFz1BEe2uI=,tag:nUgxJGCxVLNiucq0qonuwA==,type:str]
     features__sms_enabled: ENC[AES256_GCM,data:A/6kTiA=,iv:uPod+jF1JrrqZ9lFrNYzeBYrW+F7+wpVu9IsqcNS5N0=,tag:gq25B1W0OHtMiXIsY3ga0A==,type:str]
+    features__bypass_verification: ENC[AES256_GCM,data:D6G9mw==,iv:a6asU0vzE0qmPd6UiQ0YR92qERFKF1nBGPJGxGhh7SM=,tag:7ILFVHHeQAWByvFKpR60xQ==,type:str]
+    #ENC[AES256_GCM,data:q1bYxfmaWQ==,iv:Yg1PQ4XgHhmn3J/kLbcTk2ZsJKCMXNUl9MA6L194HPg=,tag:S4Lrz999aYCKR7wH1RgcAA==,type:comment]
     twilio__account_sid: ENC[AES256_GCM,data:8QQvuLf/x1pz1cR/gshSsv48kcgQziOlxfr19WgpBXq8cA==,iv:FKkdN9sgwUaPF8TxAncNAQn7ZmP8lfni1u4lPW6WdHU=,tag:fmUZt3D5HLNSmvTXX4tzpQ==,type:str]
     twilio__auth_token: ENC[AES256_GCM,data:trl9sVN+zEovyp7a0CLNV1pzWjrd+8t01nTTqoo8mwA=,iv:jgLdMIwfyvpqyFb8Mhx1NCEvovOXoiSIruGdB5tPtHE=,tag:+9Dr6FTehauQPFA/DGMyqA==,type:str]
     twilio__from_email: ENC[AES256_GCM,data:wAEQNCc912SotjDsuUWNcV/s8TF7lw==,iv:HdxlkG7JF9YwXYrtzbRrk7ioWiN4ZYTeKefuYLbvZvE=,tag:QDW2/50n5IbrLDsSe8MDhg==,type:str]
@@ -27,8 +29,8 @@ stringData:
     twilio__messaging_phone_number: ENC[AES256_GCM,data:OBOEyeuh7HzUNaa8,iv:2rEFMOuuRZmcQmv+aEBp08+eln3PiUlCE9662FXBRMM=,tag:xkP09MLMOjsOrY6pMf35DA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-29T18:20:46Z"
-    mac: ENC[AES256_GCM,data:4QrmT2Z134UEMJgv6LOghOKs1EyZorMNq0JeM4ChFK0/At9SQIDdqyU1MdhUJyHDwA0eoILZlla1+DTIIJyjH3YC9ncXMknEh4VqGOfjCx4kOY887+Hssv0w3Nk4jqm/HcwIFOJEwiwVdkiSWZDWUfvgXcjFEJdGwvxLnLPdACA=,iv:CMOxqm17sAOGr2RhwEV7mtOZnc3dnZNLq1BPcZkC32E=,tag:9P5k5RhMUyHBmCQAjLbEEA==,type:str]
+    lastmodified: "2026-06-30T00:51:35Z"
+    mac: ENC[AES256_GCM,data:mtir3EUv3S0U85zIlIXz2kJK5KkNrd+SBAo5avPKkcBjpNAmyOM06O39Kx4IYkRjFF3d/uAbU66UBjpL2jpNEWK/haeuq14xa2dkfLPdwsYVZYgynGZWOKpHfm2HIHPAmZ2Q5gLBs4p3CfNeusXwBWWaFupH5nfozct7VzuWrOQ=,iv:rvVofS5UgInvsXbdO9nL/OOTQDRGV9fD3ECCSoIciZo=,tag:DAFvn9uR5/9Jn0EJsJy1gQ==,type:str]
     pgp:
         - created_at: "2026-01-24T03:55:12Z"
           enc: |-

--- a/apps/prod/aj4democracy/aj4democracy.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.yaml
@@ -79,6 +79,11 @@ spec:
                 secretKeyRef:
                   name: aj4democracy-secrets
                   key: features__sms_enabled
+            - name: features__bypass_verification
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: features__bypass_verification
             - name: twilio__account_sid
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Set features__bypass_verification=true so a signup whose phone matches an
existing unverified record (e.g. an imported contact we can't yet text)
merges onto that record and re-verifies via the mandatory email link instead
of being rejected as a duplicate. Temporary, while SMS verification is
unavailable. Takes effect once the ajd-site image with the bypass support is
deployed.

---
**Stack**:
- #403 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*