### PR TITLE
fix(aj4democracy): set app__base_url for prod absolute URLs

### DIFF
--- a/apps/prod/aj4democracy/aj4democracy.sops.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.sops.yaml
@@ -27,10 +27,11 @@ stringData:
     twilio__from_email: ENC[AES256_GCM,data:wAEQNCc912SotjDsuUWNcV/s8TF7lw==,iv:HdxlkG7JF9YwXYrtzbRrk7ioWiN4ZYTeKefuYLbvZvE=,tag:QDW2/50n5IbrLDsSe8MDhg==,type:str]
     twilio__from_name: ENC[AES256_GCM,data:JrORLdTM8rs4w3SnsDATQr9FioN7BbJGf5zv,iv:KZkYFA20jTnJyPxnaQz2US/stRX4cn/kRMcEfwjIUeg=,tag:9FhwCwcUJ3nvJQi1Mp7LqQ==,type:str]
     twilio__messaging_phone_number: ENC[AES256_GCM,data:OBOEyeuh7HzUNaa8,iv:2rEFMOuuRZmcQmv+aEBp08+eln3PiUlCE9662FXBRMM=,tag:xkP09MLMOjsOrY6pMf35DA==,type:str]
+    app__base_url: ENC[AES256_GCM,data:l9QAjNy3BfYMf+nYgZ3VDbbKLu+DFjc9,iv:0pHe4DKWK6wKWZTKcjC5v/f36XgCaOIbPzYvVN1qD7Q=,tag:TK2H7ZdtPeitZDOmzx0fkA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-30T00:51:35Z"
-    mac: ENC[AES256_GCM,data:mtir3EUv3S0U85zIlIXz2kJK5KkNrd+SBAo5avPKkcBjpNAmyOM06O39Kx4IYkRjFF3d/uAbU66UBjpL2jpNEWK/haeuq14xa2dkfLPdwsYVZYgynGZWOKpHfm2HIHPAmZ2Q5gLBs4p3CfNeusXwBWWaFupH5nfozct7VzuWrOQ=,iv:rvVofS5UgInvsXbdO9nL/OOTQDRGV9fD3ECCSoIciZo=,tag:DAFvn9uR5/9Jn0EJsJy1gQ==,type:str]
+    lastmodified: "2026-06-30T11:19:47Z"
+    mac: ENC[AES256_GCM,data:QKZ73et3n6mo4hJAEFUbfR/tw+iu0VRQUGWuKhwzv+R6pc0v0EUUJSm9wUv7sBkKWvnlgIE6fYMPnW19UkMSIaECzWiTznWI9ey+MRTqYOvUdKntPnKNxkfwXeva61ftn7TY2zHt87IqnKhNOehC21rpZVKLsz+01J2VCG3hSDA=,iv:gTQWdWq6kkmRMYOP08MqSUaAhEcNAEteGB7iqw5JO8I=,tag:UsU+s2UkboRbm/AFYB+Hgg==,type:str]
     pgp:
         - created_at: "2026-01-24T03:55:12Z"
           enc: |-

--- a/apps/prod/aj4democracy/aj4democracy.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.yaml
@@ -9,6 +9,14 @@ spec:
       containers:
         - name: aj4democracy
           env:
+            # Public site origin for absolute URLs (og/twitter metadata, email
+            # + unsubscribe links). Kept in the sealed secret so the domain
+            # isn't committed in plaintext.
+            - name: app__base_url
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: app__base_url
             - name: nocodb__base_url
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

Adds `app__base_url` to the sealed `aj4democracy-secrets` secret and wires it into the prod `aj4democracy` Deployment via `secretKeyRef`. The origin is kept in the encrypted secret rather than committed in plaintext.

## Why

The Deployment never set `app__base_url`, so the app used its `http://localhost:3000` default in production. Every absolute URL the app emits pointed at localhost:

- **OpenGraph/Twitter `og:image` + `og:url`** → `http://localhost:3000/...`, so crawlers couldn't fetch the share card and fell back to scraping a cropped page image (the logo).
- **Email + unsubscribe links** (`lib/campaigns/compose.ts`, `lib/unsubscribe.ts`) → also localhost.

The favicon/OG card code itself is already merged and live (AJD-Site #68); this env var is the missing piece.

## Effect

The site reads `app__base_url` at request time (the `/` route is dynamic), so absolute URLs resolve to the canonical origin on the next rollout. After deploy, re-scrape in the [FB debugger](https://developers.facebook.com/tools/debug/) to refresh Facebook's cache.

## Validation

`kustomize build apps/prod/aj4democracy` renders `app__base_url` as a `secretKeyRef` env var; the secret value stays `ENC[...]`. Diff contains no plaintext origin.