### PR TITLE
fix(longhorn): escape envsubst in redirect middleware replacement

### DIFF
--- a/infrastructure/longhorn/longhorn.ingress.yaml
+++ b/infrastructure/longhorn/longhorn.ingress.yaml
@@ -18,7 +18,10 @@ metadata:
 spec:
   redirectRegex:
     regex: ^(https?://[^/]+)/longhorn$
-    replacement: ${1}/longhorn/
+    # $$ escapes the Flux postBuild envsubst so Traefik receives a literal
+    # ${1} capture group. Unescaped, envsubst resolves it as an (unset)
+    # variable -- silently emptied under Flux 2.8, a hard error under 2.9.
+    replacement: $${1}/longhorn/
     permanent: true
 ---
 # Local copy of forwardauth-authentik. Traefik isn't started with


### PR DESCRIPTION
### Description

`prod-infrastructure` stopped reconciling immediately after the Flux v2.9.2 upgrade (#409):

```
post build failed for 'Middleware.v1alpha1.traefik.containo.us/longhorn-redirect-slash':
envsubst error: variable substitution failed: variable not set (strict mode): "1"
```

`infrastructure/longhorn/longhorn.ingress.yaml` used `${1}` to reference the `redirectRegex` capture group, but that token is also valid envsubst syntax, so Flux's `postBuild` substitution consumed it as a variable named `1`.

This is not a new bug — Flux 2.9 only made it visible. Under 2.8 the unset variable was substituted with an empty string and applied silently. The middleware currently live in the cluster is:

```
replacement=/longhorn/
regex=^(https?://[^/]+)/longhorn$
```

The scheme and host have been silently stripped from the redirect this whole time. It went unnoticed because browsers resolve the relative `Location` header. Flux 2.9's strict mode turns that silent wrong value into a hard error.

Escaping as `$${1}` makes envsubst emit a literal `${1}`, so Traefik receives its capture group. This matches the escaping convention already used in `infrastructure/backup/cnpg-backup.cronjob.yaml` (`$$(date ...)`, `$$1`, `$$DIR`).

Verified this is the only affected manifest — every other `${...}` in the repo is either a real `cluster-secrets` variable or already `$$`-escaped.