### PR TITLE
fix(kutt): add startupProbe so slow boots survive the liveness probe

### DIFF
--- a/apps/base/kutt/kutt.hr.yaml
+++ b/apps/base/kutt/kutt.hr.yaml
@@ -13,6 +13,34 @@ spec:
         kind: HelmRepository
         name: christianhuth-helm-chart
         namespace: default
+  # The chart hardcodes liveness/readiness probes with no values hook and ships
+  # no startupProbe, so the liveness probe starts polling at t=0. Kutt runs
+  # `knex migrate:latest` before it listens, so a slow start -- e.g. while the
+  # CloudNativePG cluster is restarting -- gets the container killed mid-boot,
+  # which compounds into a CrashLoopBackOff. A startupProbe suspends liveness
+  # until the app is actually serving.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kutt
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kutt
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: kutt
+                        startupProbe:
+                          httpGet:
+                            path: /api/v2/health
+                            port: http
+                          periodSeconds: 10
+                          failureThreshold: 30
   values:
     image:
       repository: kutt/kutt


### PR DESCRIPTION
### Description

During the CloudNativePG operator upgrade (#401), every Postgres cluster restarted — brief and expected with `instances: 1`. authentik, plausible and nocodb reconnected on their own. Kutt instead entered `CrashLoopBackOff` and stayed there for ~6 minutes across 6 restarts before recovering unaided.

The database was not the problem. Once it was healthy, kutt's own logs showed the migration succeeding and the server starting, immediately followed by:

```
Container kutt failed liveness probe, will be restarted
```

The chart hardcodes both probes in `templates/kutt/deployment.yaml` with no values hook, and defines no `startupProbe`:

```yaml
livenessProbe:
  httpGet: {path: /api/v2/health, port: http}
readinessProbe:
  httpGet: {path: /api/v2/health, port: http}
```

With no `initialDelaySeconds`, liveness polls from t=0. Kutt runs `knex migrate:latest` before the server listens, so a slow boot burns all three failures (3 × 10s) and the kubelet kills the container mid-startup — and each kill lengthens the backoff, compounding a transient delay into a sustained outage. It survived 67 days because a warm start fits inside 30s; the DB restart pushed it past.

A `startupProbe` suspends liveness until the app is genuinely serving, allowing a 5 minute boot budget (30 × 10s) while leaving steady-state liveness behaviour untouched. Because the chart exposes no probe values, this is applied via `postRenderers` against the rendered Deployment — a new pattern for this repo, but the only mechanism available short of an upstream chart change.

Verified the rendered patch targets the single container (`kutt`) by name rather than index, and that the prod overlay defines no `postRenderers` of its own, so the base value survives the strategic merge.