### PR TITLE
chore(skills): Add dependency-upgrades skill for image/chart PRs

### DIFF
--- a/.claude/skills/dependency-upgrades/SKILL.md
+++ b/.claude/skills/dependency-upgrades/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: dependency-upgrades
+description: Batch-process container image and Helm chart dependency PRs (Renovate or manual) in this Flux GitOps repo — deduplicate, triage risk with parallel subagents, gate merges on the user, then monitor each rollout to confirmation. Use when the user says "process the Renovate PRs", "update containers and helm charts", "triage the dependency PRs", "bump deps", "go through the open dependency PRs", or "/dependency-upgrades".
+---
+
+# Dependency upgrades (containers + Helm charts)
+
+Flux CD GitOps repo, single-node k3s prod cluster (`kubectl` context `default`).
+Renovate opens one PR per image/chart bump. This skill turns a pile of those into a
+safe, verified upgrade pass:
+
+**dedupe → triage → gate on the user → merge → monitor → verify.**
+
+Two rules that never bend:
+
+- **The user merges. The skill never merges.** Present risk per track; the user clicks
+  merge; the skill watches the rollout and confirms (or surfaces failure).
+- **Plan-and-approve still applies to any fix PR** the skill opens along the way.
+
+## Secrets hygiene — read first
+
+Flux substitutes credentials into rendered HelmRelease values. Printing them leaks them
+into the transcript. **Never** run:
+
+- `kubectl get hr -o yaml`, `kubectl get hr ... -o jsonpath` wider than a single leaf
+- `helm get values`, `helm template`
+- any command that renders a whole HR/release
+
+Use instead: `flux get ...`, `kubectl describe`, and **single-leaf** jsonpath
+(`-o jsonpath='{.status.readyReplicas}'`). See memory `avoid_secret_leak_in_yaml_grep`.
+The same applies to `kubectl get secret` — never print secret data.
+
+---
+
+## Phase 1 — Enumerate & deduplicate
+
+```
+gh pr list --limit 100 --json number,title,headRefName,mergeable
+```
+Then `gh pr diff <n>` per PR to see the **actual version delta** (title isn't enough).
+
+- **Group by service.** When several PRs touch one file, keep only the **highest**
+  version; the rest are superseded (e.g. redis 0.30.8 superseded by 0.32.4). Recommend
+  closing the superseded PR — **do not close it without the user's ok.**
+- **Triage a service's image and chart together.** Authentik ships as chart PR + image
+  PR; CloudNativePG as operator chart + `cluster` chart. Their risk and rollout are
+  entangled — one report, one merge decision.
+- **Watch the tag-pin trap:** a prod overlay that pins an explicit image `tag:` overrides
+  the chart's `appVersion`. Merging the *chart* PR alone then ships nothing; the *image*
+  PR is the one that delivers the change. Read `apps/prod/<svc>/*.hr.yaml` to check.
+- **Baseline before touching anything:** cluster reachable, and green —
+  `flux get all -A --status-selector ready=false` empty, no not-ready pods.
+
+Produce a dedup table: track → PR(s) → version delta.
+
+---
+
+## Phase 2 — Triage with parallel subagents
+
+One subagent **per independent track**, all launched in a single message so they run
+concurrently. Group entangled PRs (image+chart, operator+consumer) into one subagent.
+
+Standard brief for each (adapt specifics):
+
+> Triage this Renovate upgrade. READ-ONLY: no edits, no merges, no kubectl writes
+> (read-only get/describe is fine). Respect secrets hygiene (no `-o yaml` on HRs, no
+> `helm get values`).
+> 1. Read the local HelmRelease/manifests **and prod overlays**; record exactly which
+>    values this repo sets.
+> 2. Research the upstream changelog between the two versions (WebFetch/WebSearch the
+>    release notes; for charts, diff `values.yaml`/templates at both tags).
+> 3. Cross-check: do any changed/removed/renamed values collide with what the repo sets?
+>    Any CRD change, schema migration, default flip, or forced major upgrade?
+> 4. Report: **RISK (LOW/MED/HIGH + why) · REQUIRED CONFIG CHANGES · ROLLOUT NOTES
+>    (what to watch, downtime, rollback) · MERGE ORDER**.
+> 5. **State PROVENANCE** — the exact commands/fetches behind each conclusion. If you
+>    didn't verify something, say so; do **not** reconstruct from general knowledge.
+
+Feed each subagent the relevant cluster gotchas from memory: `flux_strict_envsubst`,
+`cnpg_backup_cronjob_wedge`, `avoid_secret_leak_in_yaml_grep`,
+`longhorn_webhook_blocks_flannel`, `flux_hr_retries_exceeded`.
+
+**Reviewer discipline (this is where the value is):**
+
+- **Independently spot-check every load-bearing claim** before putting a prod merge in
+  front of the user. Read the file, run the read-only kubectl, confirm the version.
+  Multiple confident subagent findings per pass tend to be wrong; the ones that matter
+  get caught by checking the cluster, not by re-reasoning.
+- A finding written like generic knowledge with **no cited changelog/version** is a
+  guess — re-verify it yourself.
+- Idle / fast-return notifications from subagents are **noise**, not the report. Wait for
+  the actual findings; ping only if a report never arrives, and tell the agent to admit
+  gaps rather than fabricate.
+
+---
+
+## Phase 3 — Sequence & merge-gating rules
+
+Order the merges before proposing any. Hard rules learned here:
+
+- **Operator/CRDs before consumers.** CNPG operator chart before the `cluster` chart.
+  Let the operator go green (Deployment Ready + all consumers healthy) before the next.
+- **Flux itself LAST and ALONE.** It's the engine applying everything else; isolate it so
+  failure is unambiguous. Rollback is **out-of-band** — `git revert` won't self-heal a
+  crashlooping kustomize-controller:
+  ```
+  git checkout main -- clusters/prod/flux-system/gotk-components.yaml
+  kubectl apply -f clusters/prod/flux-system/gotk-components.yaml
+  ```
+  Not `flux install --version=<old>` (the local CLI regenerates new-version manifests).
+  Before merging a Flux minor, **audit manifests for `${...}` tokens** that aren't
+  cluster-secrets vars — 2.9+ strict envsubst turns those into hard failures
+  (memory `flux_strict_envsubst`).
+- **Admission controllers (Kyverno) ALONE, in a quiet window.** A restart rejects Pod
+  CREATE cluster-wide for ~60s (`failurePolicy: Fail`). Must not overlap any other
+  rollout, or the other workload's new pod gets rejected.
+- **One-way / no-rollback changes** (ClickHouse minor — on-disk format; a Postgres major)
+  gated on: a **verified fresh backup** AND any hardware pre-check (e.g. ClickHouse ≥26.6
+  needs AVX2: `grep -o avx2 /proc/cpuinfo` on the node). Confirm the backup path actually
+  exists and is current — Velero+kopia PodVolumeBackups and/or the pg_dump CronJob — don't
+  assume (memory `cnpg_backup_cronjob_wedge`; the cronjob covers only kutt/plausible/
+  authentik, nocodb rides kopia).
+- **DB-rolling changes** (`instances: 1` ⇒ hard downtime, no failover, ~10–60s per DB,
+  sequential): trigger a fresh on-demand pg_dump immediately before
+  (`kubectl create job --from=cronjob/cnpg-pg-dump-backup <name> -n default`); gate each
+  stage on **all clusters healthy + PG major version unchanged** before proceeding.
+
+Present risk per track. The user merges; monitor each.
+
+---
+
+## Phase 4 — Monitor the rollout (generation-aware)
+
+**This is the core discipline. The obvious checks lie:**
+
+- Comparing the desired pod-template image (`.spec.template...image`) against
+  `.status.readyReplicas` reports success **mid-rollout** — the OLD pod still satisfies
+  `readyReplicas`. False positive.
+- Counting a `Terminating` pod as "still present" reports failure **after** success.
+  False negative.
+
+Use `verify-rollout.sh` in this directory, or its equivalents:
+
+```
+# Simple:            verify-rollout.sh -n default deploy/kutt
+# Gate on HR:        verify-rollout.sh -n default --hr default/loki=7.1.0 sts/loki
+# Assert old gone:   verify-rollout.sh -n default --old-image 2026.5.4 \
+#                        deploy/authentik-server deploy/authentik-worker
+```
+
+It runs in the background well — launch via Bash `run_in_background`, then Read the
+output file. Under the hood it does what any trustworthy check must:
+
+1. `kubectl rollout status` (generation-aware) per workload.
+2. Optional HR gate: `lastAttemptedRevision == target` **and** Ready=True.
+3. Ignore pods with a `deletionTimestamp` and terminal job pods; flag any **running**
+   pod not Ready.
+4. Optional: assert no live pod still runs the old image tag.
+
+**Then always finish with a FUNCTIONAL check**, not just "Ready": a version query
+(`clickhouse-client --query "SELECT version()"`, `redis-server --version`), a health
+endpoint (`/api/v2/health`, Loki `/ready` + an ingestion query), or row counts. "Pod
+Ready" is necessary, not sufficient.
+
+Expectations that look like problems but aren't:
+
+- **Chart-only bumps still restart pods** when `helm.sh/chart` changes the pod-template
+  hash (authentik restarted; the cloudpirates redis chart didn't). Expect it.
+- **Alloy restart → a burst of Loki 400 `dropping data`** for entries older than
+  retention: `loki.source.kubernetes` keeps no positions file, so it re-tails from the
+  start. Self-limiting; no *current* data lost. Recurs on every alloy restart.
+- **App restarts once during a dependency (DB/cache) restart**, exiting cleanly, then
+  recovers — expected. A *second* restart, or a CrashLoopBackOff, is not (see Phase 5).
+
+**Verify config changes actually landed.** A `postRenderers` / kustomize patch can
+silently no-op (wrong target, merge-key mismatch) while the HR still reports Ready. Assert
+the field exists on the **live object**, e.g.
+`kubectl get deploy kutt -n default -o jsonpath='{.spec.template.spec.containers[0].startupProbe}'`
+— don't infer it from pod health.
+
+Per-workload failure signatures worth a dedicated grep:
+
+- DB: `pgDataImageInfo.majorVersion` changed → **stop**, don't reconcile through it.
+- ClickHouse: `Cannot attach table`, `DB::Exception`, `Illegal instruction`.
+- Flux/Kustomization: `variable not set (strict mode)` envsubst failures.
+- Any app after a dependency restart: liveness-probe-kill CrashLoopBackOff.
+
+---
+
+## Phase 5 — Verify & handle latent faults
+
+Upgrades act as **fault injection** — the restart exposes pre-existing bugs that were
+invisible while nothing restarted. When an app doesn't recover, separate the two cases:
+
+- **"The upgrade broke it"** — a real regression in the new version. Roll back per the
+  track's rollback path; report.
+- **"The upgrade exposed a latent fault"** — the new version is fine; a restart merely
+  revealed a pre-existing misconfiguration (missing startupProbe → crashloop; a wedged
+  backup CronJob; a silently-emptied envsubst value). Fix the fault as its **own PR**.
+
+For a fix PR: branch, **plan + get approval** (per global guidance), commit with **no
+co-author trailer**, PR body in this repo's style — `### Description` only (memory
+`flux_infra_pr_style`). If the chart hardcodes the thing you need to change (no values
+hook), use `spec.postRenderers` with a kustomize patch — then verify per Phase 4 that the
+patch actually landed.
+
+Wrap-up each pass:
+
+- Close superseded PRs (with approval).
+- Record follow-ups the triage surfaced (value pins, orphaned PVCs, alerting gaps,
+  chart migrations).
+- If the pass revealed a new durable cluster gotcha, add a memory file and index it in
+  `MEMORY.md`.
+
+---
+
+## Reference
+
+- Helper: `verify-rollout.sh` (this directory) — `--help` for usage.
+- Living cluster gotchas: the user's memory files, cited by name above. Prefer pointing
+  at them over duplicating, so this skill stays in sync as they change.

--- a/.claude/skills/dependency-upgrades/verify-rollout.sh
+++ b/.claude/skills/dependency-upgrades/verify-rollout.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# verify-rollout.sh — generation-aware rollout verification for Flux-managed workloads.
+#
+# Distilled from the dependency-upgrade monitoring done by the `dependency-upgrades`
+# skill. It exists because the obvious checks lie:
+#   - comparing the desired pod-template image against .status.readyReplicas reports
+#     success mid-rollout (the OLD pod still satisfies readyReplicas) — false positive.
+#   - counting a Terminating pod as "still present" reports failure after success —
+#     false negative.
+# So this uses `kubectl rollout status` (generation-aware), ignores pods with a
+# deletionTimestamp, optionally gates on the HelmRelease revision + Ready condition,
+# and can assert no live pod still runs the old image.
+#
+# READ-ONLY: only `kubectl get`/`rollout status`/`describe`. No writes, no secrets
+# printed (never dumps HR values or wide YAML).
+#
+# Usage:
+#   verify-rollout.sh -n <namespace> [options] <workload> [<workload> ...]
+#
+#   <workload>   deploy/<name> | sts/<name> | ds/<name>   (statefulset/daemonset ok)
+#
+# Options:
+#   -n, --namespace <ns>        Namespace (required).
+#       --hr <ns/name=version>  Gate on HelmRelease: wait until lastAttemptedRevision
+#                               == version AND Ready=True. Fail fast on Ready=False.
+#       --old-image <substr>    Fail if any live (non-terminating) pod in <ns> still
+#                               runs an image containing <substr>.
+#       --timeout <seconds>     Per-workload rollout timeout (default 300).
+#   -h, --help
+#
+# Exit: 0 = every check passed; non-zero = at least one failed (safe for backgrounding
+# via Bash run_in_background, then Read the output file).
+#
+# Examples:
+#   verify-rollout.sh -n default deploy/kutt
+#   verify-rollout.sh -n default --hr default/loki=7.1.0 sts/loki
+#   verify-rollout.sh -n default --old-image 2026.5.4 deploy/authentik-server deploy/authentik-worker
+
+set -uo pipefail
+
+NS=""
+HR_SPEC=""
+OLD_IMAGE=""
+TIMEOUT=300
+WORKLOADS=()
+
+die() { echo "error: $*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--namespace) NS="${2:-}"; shift 2 ;;
+    --hr)           HR_SPEC="${2:-}"; shift 2 ;;
+    --old-image)    OLD_IMAGE="${2:-}"; shift 2 ;;
+    --timeout)      TIMEOUT="${2:-}"; shift 2 ;;
+    -h|--help)      sed -n '2,40p' "$0"; exit 0 ;;
+    -*)             die "unknown option: $1" ;;
+    *)              WORKLOADS+=("$1"); shift ;;
+  esac
+done
+
+[ -n "$NS" ] || die "namespace is required (-n <ns>)"
+[ "${#WORKLOADS[@]}" -gt 0 ] || die "at least one workload is required (deploy/x, sts/y, ds/z)"
+
+FAIL=0
+note_fail() { echo "  FAIL: $*"; FAIL=1; }
+
+# ---------------------------------------------------------------------------
+# 1. HelmRelease gate (optional): revision reached target AND Ready=True.
+# ---------------------------------------------------------------------------
+if [ -n "$HR_SPEC" ]; then
+  hr_ns_name="${HR_SPEC%%=*}"
+  hr_version="${HR_SPEC#*=}"
+  hr_ns="${hr_ns_name%%/*}"
+  hr_name="${hr_ns_name#*/}"
+  [ "$hr_ns" != "$hr_ns_name" ] || die "--hr must be ns/name=version, got: $HR_SPEC"
+  echo "[hr] $hr_ns/$hr_name -> $hr_version"
+  ok=0
+  for _ in $(seq 1 60); do
+    rev=$(kubectl get hr "$hr_name" -n "$hr_ns" -o jsonpath='{.status.lastAttemptedRevision}' 2>/dev/null)
+    ready=$(kubectl get hr "$hr_name" -n "$hr_ns" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+    if [ "$ready" = "False" ]; then
+      msg=$(kubectl get hr "$hr_name" -n "$hr_ns" -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null)
+      note_fail "HelmRelease Ready=False at revision '${rev}': ${msg}"
+      ok=1; break
+    fi
+    if [ "$ready" = "True" ] && [ "$rev" = "$hr_version" ]; then
+      echo "  ok: revision=$rev Ready=True"; ok=1; break
+    fi
+    sleep 10
+  done
+  [ "$ok" = "1" ] || note_fail "HelmRelease did not reach $hr_version/Ready in time (rev=$rev ready=$ready)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Per-workload rollout status (generation-aware).
+# ---------------------------------------------------------------------------
+for w in "${WORKLOADS[@]}"; do
+  echo "[rollout] $w"
+  if out=$(kubectl rollout status "$w" -n "$NS" --timeout="${TIMEOUT}s" 2>&1); then
+    echo "  ok: $(echo "$out" | tail -1)"
+  else
+    note_fail "$w did not complete: $(echo "$out" | tail -1)"
+    echo "  --- pods ---"
+    kubectl get pods -n "$NS" -o wide --no-headers 2>/dev/null | sed 's/^/    /' | head -20
+    echo "  --- recent events ---"
+    kubectl get events -n "$NS" --sort-by=.lastTimestamp 2>/dev/null | tail -8 | sed 's/^/    /'
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. Live (non-terminating) pods that are not Ready. Terminal job pods ignored.
+# ---------------------------------------------------------------------------
+echo "[readiness] non-terminating pods not Ready"
+notready=$(kubectl get pods -n "$NS" -o json 2>/dev/null | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+bad = []
+for p in d.get("items", []):
+    m = p.get("metadata", {})
+    s = p.get("status", {})
+    if m.get("deletionTimestamp"):            # Terminating -> not "live"
+        continue
+    if s.get("phase") in ("Succeeded", "Failed"):  # completed job pods
+        continue
+    ready = next((c["status"] for c in s.get("conditions", []) if c["type"] == "Ready"), "?")
+    if ready != "True":
+        bad.append("%s phase=%s ready=%s" % (m["name"], s.get("phase"), ready))
+print("\n".join(bad))
+')
+if [ -n "$notready" ]; then
+  echo "$notready" | sed 's/^/  /'
+  note_fail "$(echo "$notready" | wc -l | tr -d ' ') running pod(s) not Ready"
+else
+  echo "  ok: all live pods Ready"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Old-image assertion (optional): no live pod may still run the old tag.
+# ---------------------------------------------------------------------------
+if [ -n "$OLD_IMAGE" ]; then
+  echo "[old-image] no live pod may run image containing '$OLD_IMAGE'"
+  stragglers=$(kubectl get pods -n "$NS" -o json 2>/dev/null | python3 -c "
+import json, sys
+old = sys.argv[1]
+d = json.load(sys.stdin)
+hits = []
+for p in d.get('items', []):
+    if p.get('metadata', {}).get('deletionTimestamp'):
+        continue
+    for c in p.get('spec', {}).get('containers', []):
+        if old in c.get('image', ''):
+            hits.append(f\"{p['metadata']['name']} -> {c['image']}\")
+print('\n'.join(hits))
+" "$OLD_IMAGE")
+  if [ -n "$stragglers" ]; then
+    echo "$stragglers" | sed 's/^/  /'
+    note_fail "old-image pods still live"
+  else
+    echo "  ok: none"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS: rollout verified in ns/$NS"
+else
+  echo "FAIL: one or more checks failed in ns/$NS — see above"
+fi
+exit "$FAIL"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# `.claude/` is ignored by the user's global git excludes
+# (~/.config/git/ignore). Re-include repo-local skills so they are
+# versioned with this repo, while keeping the rest of .claude/ ignored
+# (settings.local.json, plans, session state, etc.).
+!.claude/
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
### Description

Adds a repo-local `dependency-upgrades` skill that captures how Renovate
container-image and Helm-chart PRs get processed in this repo: deduplicate,
triage each bump for risk with parallel subagents, gate merges on a human,
then verify each rollout. It exists so the next upgrade pass follows the same
discipline instead of re-deriving it — and so the rollout-verification traps
that bite every time are written down once.

The crux is generation-aware rollout checking, which naive checks get wrong in
both directions: comparing the desired pod image against `readyReplicas`
reports success while the old pod is still serving, and counting a Terminating
pod as live reports failure after success. The bundled `verify-rollout.sh`
avoids both — `kubectl rollout status` for generation awareness, excludes
Terminating pods, optionally gates on the HelmRelease revision, and asserts no
old-image pod survives. Verified against live workloads including the failure
path (asserting a still-present image exits non-zero).

`.claude/` is ignored by a global git exclude, so the added `.gitignore`
re-includes `.claude/skills/` only — versioning the skill with the repo while
keeping local settings and plans ignored.
