### PR TITLE
fix(aj4democracy): Add missing campaign env to the prod overlay

### DIFF
--- a/apps/prod/aj4democracy/aj4democracy.sops.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.sops.yaml
@@ -15,6 +15,10 @@ stringData:
     nocodb__presigned_links__view_id: ENC[AES256_GCM,data:0wyCe6G1Mid+cOKtB4u8zQ==,iv:hTSbWo7vq6scj7LVN+foW/AXDP1KipdM6q2Yr9libF0=,tag:yMk5map2OPwK+X7Ni0WT6g==,type:str]
     nocodb__candidates__table_id: ENC[AES256_GCM,data:k61MyTYJL8MID7mm9yGm,iv:x+kBNiihMPXcJGkoEk0365hUsfZ8SEdS2TqZwq0GzFw=,tag:7PBOKRmiMTZbBhJOEx5+1Q==,type:str]
     nocodb__candidates__view_id: ENC[AES256_GCM,data:cepMvAWtfFCvIyY2ApTziA==,iv:gKycHJCmo7RuF/qS2yUz5n/XBN8vMjxH/RZJ4jWxnv4=,tag:cPP9FEjZd+xHDTh5XL4NNg==,type:str]
+    nocodb__campaigns__table_id: ENC[AES256_GCM,data:B5aySDv3B/I6uPTqCPvA,iv:meuGHy/dRN2AyFcdwgIYpr/KCl8dxkMfepDr8dBWN5E=,tag:hV5XpioCWPDzYoF2al6VHQ==,type:str]
+    nocodb__campaigns__view_id: ENC[AES256_GCM,data:zdgYxQ8dLCT/Qpv36aGvlQ==,iv:AyqRJgVJdgdrQ/elgdHkQm/tlbP5g3M4F/FJshiK1+k=,tag:c0AYJpsoanPslwFb/PYJCg==,type:str]
+    nocodb__campaign_sends__table_id: ENC[AES256_GCM,data:6Zy0jiAOaWlhkXU9qZOh,iv:AfXTXeV7cLQXHalc6vZx8a/Oi7srfNP53LPFW2BJTos=,tag:sTu+Vvorz5to94RZ3B0lbA==,type:str]
+    nocodb__campaign_sends__view_id: ENC[AES256_GCM,data:YVDMKrHURXUMsTw9bOMRMA==,iv:2nju+fLgVXYtxApSFN5ZL/BW9THgH0W3IyEgJLIlFQc=,tag:KfdYm23uP+zhUIOkl2HdCA==,type:str]
     #ENC[AES256_GCM,data:g5tGcxiRMcQvumY/Sw==,iv:mtRMV6wjac9glUezcEea4kyIchA37RTc68jxKeJvbhU=,tag:6Jw534S2dsHD8RABRD3neg==,type:comment]
     features__geocodio_api_key: ENC[AES256_GCM,data:bkrbxj2ArfA0Y9P4bOqtCz7yJBTueF/WetL3+UL93324hSUQe1Q3,iv:CjeRwicqPYhcbuSYK2blOIZ6Ek+U5tzTfmjP6splZlo=,tag:DE7NUiUZc+NfvTJha48GIw==,type:str]
     features__whatsapp_link: ENC[AES256_GCM,data:jKWoTmwUH/S/8DQwlizdwtEbLv1nMxwBNvwlN/Tlh5qI95S1iUW9wtwTdyUkZh5Mlg==,iv:GmCuR61Ner0xC7kgBNml5Gzy6j/dSqbMoOSurmt+/ww=,tag:L3ufo6GZxA1rTDSaqtoNqw==,type:str]
@@ -28,10 +32,13 @@ stringData:
     twilio__from_name: ENC[AES256_GCM,data:JrORLdTM8rs4w3SnsDATQr9FioN7BbJGf5zv,iv:KZkYFA20jTnJyPxnaQz2US/stRX4cn/kRMcEfwjIUeg=,tag:9FhwCwcUJ3nvJQi1Mp7LqQ==,type:str]
     twilio__messaging_phone_number: ENC[AES256_GCM,data:OBOEyeuh7HzUNaa8,iv:2rEFMOuuRZmcQmv+aEBp08+eln3PiUlCE9662FXBRMM=,tag:xkP09MLMOjsOrY6pMf35DA==,type:str]
     app__base_url: ENC[AES256_GCM,data:l9QAjNy3BfYMf+nYgZ3VDbbKLu+DFjc9,iv:0pHe4DKWK6wKWZTKcjC5v/f36XgCaOIbPzYvVN1qD7Q=,tag:TK2H7ZdtPeitZDOmzx0fkA==,type:str]
+    #ENC[AES256_GCM,data:5EVG/YMgHGqRMQ==,iv:zeEM1K4ZMcJSo6IyxWshm89IDNUfHpPgvUpiaAkCO9E=,tag:GgmjDHi37js3WQT9vMZxyA==,type:comment]
+    campaigns__webhook_secret: ENC[AES256_GCM,data:A93HnDTAnSuVaX7XKMp3OZvKYLzBVejPDEhwtMSzGMF0fCphgAUUaoRCZ3OVMu8THQCkpfrDM2UY4v3BmwRH1Q==,iv:Acvkav55sW/N2BwbGHApwuUaxdSDOImimG5KFB50pj4=,tag:fRZrbA5BfxVF+kua3xDHhw==,type:str]
+    unsubscribe__secret: ENC[AES256_GCM,data:Plb7BqAvwtaRdCou1RNH4wQbfAXNcZo5AwxEgQI2vbrwTwu+3GDyZsw0Ceo3XkBzOMcDRaMSo0nS/FQ4Iiy8Dg==,iv:mw7XEfQtFzOYum37blTXKpymYyaIQM1qYJVoI7HxwQY=,tag:CWtacf4Ofqe3KFUTnEggzQ==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-30T11:19:47Z"
-    mac: ENC[AES256_GCM,data:QKZ73et3n6mo4hJAEFUbfR/tw+iu0VRQUGWuKhwzv+R6pc0v0EUUJSm9wUv7sBkKWvnlgIE6fYMPnW19UkMSIaECzWiTznWI9ey+MRTqYOvUdKntPnKNxkfwXeva61ftn7TY2zHt87IqnKhNOehC21rpZVKLsz+01J2VCG3hSDA=,iv:gTQWdWq6kkmRMYOP08MqSUaAhEcNAEteGB7iqw5JO8I=,tag:UsU+s2UkboRbm/AFYB+Hgg==,type:str]
+    lastmodified: "2026-08-09T12:31:06Z"
+    mac: ENC[AES256_GCM,data:Iub580j4MHhkTy3+w/tUma31wEc7PXNXPqmiKZnTI8jAlvPvHb5DM4f2JQGRowyQfdm37TFatMyhqi3NeGn6g0Z3xRlqB/2hxjI2Y8nvAT78IRrKsoa33JSR72OQe6dbrFuld+rDxJQ/SUvF17HupTbFPAdekbZ9Da15WzzYKp0=,iv:fW2RbdvPyl1cnePebhLZ91kJ01nERgc4YvEyTFAk+DQ=,tag:ZGIPFRSpUHM2JJbGgMw2kA==,type:str]
     pgp:
         - created_at: "2026-01-24T03:55:12Z"
           enc: |-
@@ -53,4 +60,4 @@ sops:
             =udQB
             -----END PGP MESSAGE-----
           fp: 7EB1A78D86B11352982D3A1F7037153C2DB9CDBD
-    version: 3.13.1
+    version: 3.13.3

--- a/apps/prod/aj4democracy/aj4democracy.yaml
+++ b/apps/prod/aj4democracy/aj4democracy.yaml
@@ -67,6 +67,26 @@ spec:
                 secretKeyRef:
                   name: aj4democracy-secrets
                   key: nocodb__candidates__view_id
+            - name: nocodb__campaigns__table_id
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: nocodb__campaigns__table_id
+            - name: nocodb__campaigns__view_id
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: nocodb__campaigns__view_id
+            - name: nocodb__campaign_sends__table_id
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: nocodb__campaign_sends__table_id
+            - name: nocodb__campaign_sends__view_id
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: nocodb__campaign_sends__view_id
             - name: features__geocodio_api_key
               valueFrom:
                 secretKeyRef:
@@ -117,3 +137,15 @@ spec:
                 secretKeyRef:
                   name: aj4democracy-secrets
                   key: twilio__messaging_phone_number
+            # Authenticates the NocoDB webhook that triggers a campaign send.
+            - name: campaigns__webhook_secret
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: campaigns__webhook_secret
+            # Signs the stateless HMAC email unsubscribe tokens.
+            - name: unsubscribe__secret
+              valueFrom:
+                secretKeyRef:
+                  name: aj4democracy-secrets
+                  key: unsubscribe__secret


### PR DESCRIPTION
Public campaign posts at `/posts/<slug>` now render; previously every
request to that route returned a 500, including unknown slugs that should
have been a plain 404. `POST /api/campaigns/send` now authenticates its
callers instead of rejecting all of them with "Campaign sending is not
configured"; it stays inert until a NocoDB webhook is pointed at it.

## Why

Added are the NocoDB table and view IDs for
the `Campaigns` and `CampaignSends` tables, the shared secret that
authenticates the send webhook, and the key that signs email unsubscribe
tokens.

