### PR TITLE
feat(changedetection): Add change monitoring at /watcher

### DIFF
--- a/apps/base/changedetection/changedetection.hr.yaml
+++ b/apps/base/changedetection/changedetection.hr.yaml
@@ -1,0 +1,62 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: changedetection
+  namespace: default
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: changedetection
+      version: 1.1.14
+      sourceRef:
+        kind: HelmRepository
+        name: helmforge-charts
+        namespace: default
+  values:
+    # Without this the chart names everything "<release>-<chart>", i.e.
+    # changedetection-changedetection.
+    fullnameOverride: changedetection
+    image:
+      repository: ghcr.io/dgtlmoon/changedetection.io
+      tag: "0.55.8"
+    changedetection:
+      port: 5000
+      timezone: America/New_York
+      # Kustomize replaces YAML lists wholesale rather than merging them, so this
+      # list is the complete set -- an overlay that re-declares extraEnv silently
+      # drops everything below.
+      extraEnv:
+        # Wraps the Flask app in werkzeug ProxyFix(x_prefix=1), which sets
+        # SCRIPT_NAME from X-Forwarded-Prefix so url_for() emits sub-path-prefixed
+        # links. Inert unless a proxy actually sends the header, so it is safe to
+        # default on even for a root-path deployment.
+        - name: USE_X_SETTINGS
+          value: "1"
+        # Reject bare hostnames (http://nas, http://authentik-server) as watch
+        # targets. RFC1918 and other IANA-reserved addresses are already refused by
+        # default via ALLOW_IANA_RESTRICTED_ADDRESSES=false.
+        - name: BLOCK_SIMPLEHOSTS
+          value: "true"
+    browser:
+      enabled: true
+      image:
+        repository: ghcr.io/browserless/chromium
+        tag: "v2.46.0"
+      # The chart leaves the sidecar unbounded; Chromium will happily eat the node.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+    persistence:
+      enabled: true
+      existingClaim: changedetection-data-pvc
+    service:
+      port: 80
+    # Routing is an overlay concern: the chart's Ingress cannot attach the Traefik
+    # middlewares that sub-path hosting and forward-auth need.
+    ingress:
+      enabled: false

--- a/apps/base/changedetection/changedetection.pvc.yaml
+++ b/apps/base/changedetection/changedetection.pvc.yaml
@@ -1,0 +1,15 @@
+# Declared here rather than letting the chart template it: a chart-managed PVC is a
+# release resource, so `helm uninstall` -- or the HelmRelease being pruned -- would
+# take the SQLite datastore and every change snapshot with it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: changedetection-data-pvc
+  namespace: default
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/base/changedetection/kustomization.yaml
+++ b/apps/base/changedetection/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - changedetection.pvc.yaml
+  - changedetection.hr.yaml

--- a/apps/prod/authentik/authentik.hr.yaml
+++ b/apps/prod/authentik/authentik.hr.yaml
@@ -59,6 +59,7 @@ spec:
         - media-blueprint
         - jellyfin-blueprint
         - kutt-blueprint
+        - watcher-blueprint
         - embedded-outpost-blueprint
         - home-outpost-blueprint
         - ops-group-blueprint

--- a/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
@@ -53,3 +53,4 @@ data:
             - !Find [authentik_providers_proxy.proxyprovider, [name, ops-forward-auth]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-forward-auth]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-forward-auth]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, watcher-forward-auth]]

--- a/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/groups/apps-group.blueprint.yaml
@@ -39,3 +39,10 @@ data:
           order: 1
         attrs:
           enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, watcher]]
+          group: !KeyOf apps-group
+          order: 2
+        attrs:
+          enabled: true

--- a/apps/prod/authentik/blueprints/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - media
   - jellyfin
   - kutt
+  - watcher
   - embedded-outpost
   - home-outpost
   - groups

--- a/apps/prod/authentik/blueprints/watcher/kustomization.yaml
+++ b/apps/prod/authentik/blueprints/watcher/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - watcher.blueprint.yaml

--- a/apps/prod/authentik/blueprints/watcher/watcher.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/watcher/watcher.blueprint.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: watcher-blueprint
+  namespace: default
+data:
+  watcher.yaml: |
+    version: 1
+    metadata:
+      name: watcher-forward-auth
+    entries:
+      # forward_single providers are scoped to a host, so this one nominally covers
+      # all of ${SECRET_DOMAIN}. Only the /watcher IngressRoute actually attaches the
+      # forwardauth-authentik middleware, so the rest of the site stays public.
+      - model: authentik_providers_proxy.proxyprovider
+        id: watcher-provider
+        identifiers:
+          name: watcher-forward-auth
+        attrs:
+          name: Watcher Forward Auth Provider
+          external_host: https://${SECRET_DOMAIN}
+          # internal_host is unused in forward_single mode but required by the serializer.
+          internal_host: http://localhost
+          internal_host_ssl_validation: false
+          mode: forward_single
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      - model: authentik_core.application
+        id: watcher-app
+        identifiers:
+          slug: watcher
+        attrs:
+          name: Watcher
+          slug: watcher
+          provider: !KeyOf watcher-provider
+          meta_launch_url: https://${SECRET_DOMAIN}/watcher/
+          icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/changedetection.svg
+          meta_description: changedetection.io website change monitoring
+          open_in_new_tab: true
+          group: Apps
+          policy_engine_mode: any

--- a/apps/prod/changedetection/changedetection.hr.yaml
+++ b/apps/prod/changedetection/changedetection.hr.yaml
@@ -1,0 +1,134 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: changedetection
+  namespace: default
+spec:
+  # changedetection.io has no environment variable for the default notification
+  # target -- `settings.application.notification_urls` lives only inside the
+  # datastore JSON, which the app normally writes from its own Settings UI. This
+  # init container renders the apprise URL from the shared noreply SMTP creds on
+  # every start so the credentials stay GitOps-managed instead of being pasted in
+  # by hand. Notification URLs pointing anywhere else are preserved, so extra
+  # targets added through the UI survive a restart.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: changedetection
+            # JSON 6902 rather than a strategic merge: this has to run *after* the
+            # chart's own `initialize-datastore` init container, which is what
+            # creates /datastore/changedetection.json, and a strategic merge
+            # prepends the new entry instead of appending it.
+            #
+            # `initialize-datastore` only exists while
+            # changedetection.defaultWatches.enabled is false (the chart default).
+            # If that is ever flipped, this container fails loudly on the missing
+            # file rather than silently skipping the seed.
+            patch: |
+              - op: add
+                path: /spec/template/spec/initContainers/-
+                value:
+                  name: seed-notification-url
+                  # Should track image.tag in the base HelmRelease, but Renovate
+                  # cannot see inside this patch string. A drifted tag is harmless:
+                  # the script below is Python stdlib only.
+                  image: ghcr.io/dgtlmoon/changedetection.io:0.55.8
+                  imagePullPolicy: IfNotPresent
+                  env:
+                    - name: SMTP_HOST
+                      value: "${NOREPLY_HOST}"
+                    - name: SMTP_PORT
+                      value: "465"
+                    - name: SMTP_USER
+                      valueFrom:
+                        secretKeyRef:
+                          name: noreply-email-secrets
+                          key: NOREPLY_AUTH_EMAIL
+                    - name: SMTP_PASS
+                      valueFrom:
+                        secretKeyRef:
+                          name: noreply-email-secrets
+                          key: NOREPLY_PASSWORD
+                    - name: SMTP_FROM
+                      valueFrom:
+                        secretKeyRef:
+                          name: noreply-email-secrets
+                          key: NOREPLY_SEND_EMAIL
+                    - name: NOTIFY_TO
+                      value: "${EMAIL}"
+                  # Repeated verbatim from the chart's securityContext: a container
+                  # injected by a post-renderer does not inherit it, and would
+                  # otherwise run as root and leave root-owned files in the datastore.
+                  securityContext:
+                    runAsUser: 1000
+                    runAsGroup: 1000
+                    runAsNonRoot: true
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                  volumeMounts:
+                    - name: data
+                      mountPath: /datastore
+                  command:
+                    - python
+                    - -c
+                    - |
+                      import json
+                      import os
+                      from urllib.parse import quote
+
+                      DATASTORE = "/datastore/changedetection.json"
+
+                      def q(value):
+                          # Credentials go in the query string, not the userinfo
+                          # section: apprise honours ?user=/?pass= overrides, which
+                          # avoids having to encode the "@" in an email-shaped
+                          # username. Everything is still percent-encoded so an "&"
+                          # or "#" in the app password cannot break the URL.
+                          return quote(value, safe="")
+
+                      if not os.path.exists(DATASTORE):
+                          raise SystemExit(
+                              DATASTORE + " is missing -- the chart's"
+                              " initialize-datastore init container must run first"
+                              " (changedetection.defaultWatches.enabled must stay false)"
+                          )
+
+                      host = os.environ["SMTP_HOST"]
+                      url = (
+                          "mailtos://{host}:{port}/"
+                          "?user={user}&pass={password}&from={sender}&to={rcpt}&mode=ssl"
+                      ).format(
+                          host=q(host),
+                          port=q(os.environ["SMTP_PORT"]),
+                          user=q(os.environ["SMTP_USER"]),
+                          password=q(os.environ["SMTP_PASS"]),
+                          sender=q(os.environ["SMTP_FROM"]),
+                          rcpt=q(os.environ["NOTIFY_TO"]),
+                      )
+
+                      with open(DATASTORE) as handle:
+                          data = json.load(handle)
+
+                      application = data.setdefault("settings", {}).setdefault("application", {})
+                      current = application.get("notification_urls", [])
+                      others = [u for u in current if not u.startswith("mailtos://" + q(host))]
+                      desired = [url] + others
+
+                      if current == desired:
+                          print("default notification URL already current")
+                      else:
+                          application["notification_urls"] = desired
+                          with open(DATASTORE + ".tmp", "w") as handle:
+                              json.dump(data, handle, indent=4)
+                          os.replace(DATASTORE + ".tmp", DATASTORE)
+                          print("seeded default notification URL")
+  values:
+    changedetection:
+      # Only used to build absolute links inside notification bodies; the request
+      # path itself comes from the X-Forwarded-Prefix the stripPrefix middleware
+      # sets. See changedetection.ingressroute.yaml.
+      baseUrl: https://${SECRET_DOMAIN}/watcher

--- a/apps/prod/changedetection/changedetection.ingressroute.yaml
+++ b/apps/prod/changedetection/changedetection.ingressroute.yaml
@@ -1,0 +1,65 @@
+# Normalize /watcher -> /watcher/ before stripPrefix runs, so the backend never
+# sees an empty path.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: changedetection-redirect-slash
+  namespace: default
+spec:
+  redirectRegex:
+    regex: ^(https?://[^/]+)/watcher$
+    # $$ escapes the Flux postBuild envsubst so Traefik receives a literal
+    # ${1} capture group. Unescaped, envsubst resolves it as an (unset)
+    # variable -- silently emptied under Flux 2.8, a hard error under 2.9.
+    replacement: $${1}/watcher/
+    permanent: true
+---
+# Traefik's stripPrefix *adds* X-Forwarded-Prefix rather than setting it, and
+# changedetection reads the first value of that header. Without this, a client
+# could supply its own prefix and dictate the app's session cookie path and
+# socket.io endpoint. An empty customRequestHeaders value deletes the header.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: changedetection-clear-fwd-prefix
+  namespace: default
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Prefix: ""
+---
+# Strips /watcher and sets the trusted X-Forwarded-Prefix that USE_X_SETTINGS
+# turns into Flask's SCRIPT_NAME.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: changedetection-stripprefix
+  namespace: default
+spec:
+  stripPrefix:
+    prefixes:
+      - /watcher
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: changedetection
+  namespace: default
+spec:
+  routes:
+    # PathPrefix is a raw string prefix in Traefik v2, not a path-segment match, so
+    # `/watcher` alone would also swallow /watchers and /watcher-anything. Match the
+    # /watcher segment explicitly instead.
+    - match: Host(`${SECRET_DOMAIN}`) && (Path(`/watcher`) || PathPrefix(`/watcher/`))
+      kind: Rule
+      services:
+        - name: changedetection
+          port: 80
+      # Order matters: forward-auth has to see the original /watcher/... URI so
+      # authentik redirects back to the right place after login, which means it
+      # must run before the prefix is stripped.
+      middlewares:
+        - name: changedetection-redirect-slash
+        - name: forwardauth-authentik
+        - name: changedetection-clear-fwd-prefix
+        - name: changedetection-stripprefix

--- a/apps/prod/changedetection/kustomization.yaml
+++ b/apps/prod/changedetection/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/changedetection
+  - changedetection.ingressroute.yaml
+patches:
+  - path: changedetection.hr.yaml
+    target:
+      kind: HelmRelease
+      name: changedetection

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - prometheus
   - authentik
   - aj4democracy
+  - changedetection
   - dysautonomia-web
   - jpat-web
   - kutt

--- a/charts/helmforge.chart.yaml
+++ b/charts/helmforge.chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: helmforge-charts
+  namespace: default
+spec:
+  interval: 30m
+  url: https://repo.helmforge.dev
+  timeout: 2m

--- a/charts/kustomization.yaml
+++ b/charts/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - cloudnativepg.chart.yaml
   - cloudpirates.chart.yaml
   - grafana.chart.yaml
+  - helmforge.chart.yaml
   - kyverno.chart.yaml
   - lacework.chart.yaml
   - longhorn.chart.yaml

--- a/infrastructure/ingress/traefik/authentik.ingress.yaml
+++ b/infrastructure/ingress/traefik/authentik.ingress.yaml
@@ -8,7 +8,10 @@ metadata:
     app.kubernetes.io/name: authentik
 spec:
   routes:
-    - match: (Host(`ops.${SECRET_DOMAIN}`) || Host(`prometheus.${SECRET_DOMAIN}`) || Host(`alert-manager.${SECRET_DOMAIN}`)) && PathPrefix(`/outpost.goauthentik.io`)
+    # ${SECRET_DOMAIN} is the apex host: only its /watcher route is forward-auth
+    # gated, but the outpost callback has to resolve on the same host as the
+    # protected path or the post-login redirect breaks.
+    - match: (Host(`ops.${SECRET_DOMAIN}`) || Host(`prometheus.${SECRET_DOMAIN}`) || Host(`alert-manager.${SECRET_DOMAIN}`) || Host(`${SECRET_DOMAIN}`)) && PathPrefix(`/outpost.goauthentik.io`)
       kind: Rule
       services:
         - name: authentik-server


### PR DESCRIPTION
changedetection.io now runs at `https://serubin.net/watcher`, gated by
Authentik forward-auth through the Apps group and mailing change
notifications from the shared noreply account. A browserless sidecar
covers JavaScript-rendered pages.

## Implementation

The app has no environment variable for its default notification
target: `notification_urls` lives only in the datastore JSON, normally
written through the Settings UI. A post-render init container renders
the apprise `mailtos://` URL from `noreply-email-secrets` on every
start, so the credentials stay in SOPS instead of being pasted into the
app by hand. Targets added through the UI survive.

`${SECRET_DOMAIN}` is the first apex host to carry forward-auth, so the
outpost callback path is now routed there too. Only `/watcher` attaches
the middleware; the rest of the site stays public.

## Risks

Port 465/SSL for `${NOREPLY_HOST}` is assumed from nocodb's setup;
authentik uses 587/STARTTLS for the same account. That is the knob if
the first test notification fails.
