### PR TITLE
fix(authentik): Unblock the embedded-outpost blueprint

### DIFF
--- a/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
+++ b/apps/prod/authentik/blueprints/embedded-outpost/embedded-outpost.blueprint.yaml
@@ -46,7 +46,12 @@ data:
             kubernetes_image_pull_secrets: []
             kubernetes_json_patches: null
             kubernetes_ingress_class_name: null
-            kubernetes_ingress_secret_name: null
+            # Must be a string: the outpost config serializer rejects null here
+            # ('should be "str" instead of value "None"'), which silently failed
+            # the whole blueprint and froze the providers list below. The other
+            # null keys in this block are still accepted. This is authentik's own
+            # default value; the outpost creates no Ingress, so it goes unused.
+            kubernetes_ingress_secret_name: authentik-outpost-tls
             kubernetes_ingress_annotations: {}
             refresh_interval: minutes=5
           providers:


### PR DESCRIPTION
The embedded outpost's `providers` list is reconciled from Git again.
It had frozen at ops, prometheus and alertmanager: forward-auth
providers added since then were written to the blueprint but never
bound, so their routes answered 404 instead of redirecting to login.
`watcher-forward-auth`, added in #471, was the first to hit this.

## Why

`kubernetes_ingress_secret_name: null` is no longer accepted by the
outpost config serializer:

```
Failed to validate config: wrong value type for field
"kubernetes_ingress_secret_name" - should be "str" instead of
value "None" of type "NoneType"
```

One invalid key fails the whole blueprint, so the entry silently
stopped applying at whichever upgrade tightened that field. Nothing
surfaces this except the blueprint's `error` status in the admin UI.

`authentik-outpost-tls` is authentik's own default for the field, and
matches what the live outpost already has. The embedded outpost creates
no Ingress, so the value goes unused either way. The other `null` keys
in that config block are still accepted — I re-validated the blueprint
against the running instance with only this line changed.
